### PR TITLE
[2/n] Add base server configuration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["render-conjure"]
+members = ["render-conjure", "witchcraft-server", "witchcraft-server-config"]
 
 [patch.crates-io]
 conjure-runtime-config = { git = "https://github.com/palantir/conjure-rust-runtime" }

--- a/witchcraft-server-config/Cargo.toml
+++ b/witchcraft-server-config/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "witchcraft-server-config"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+conjure-runtime-config = "1"
+humantime-serde = "1"
+num_cpus = "1"
+serde = { version = "1", features = ["derive"] }
+witchcraft-log = "0.3"

--- a/witchcraft-server-config/src/install.rs
+++ b/witchcraft-server-config/src/install.rs
@@ -1,0 +1,290 @@
+// Copyright 2021 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//! Fixed configuration.
+use serde::{de, Deserialize, Deserializer};
+use std::env;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+/// The fixed configuration for a Witchcraft server.
+#[derive(Deserialize, Clone, PartialEq, Debug)]
+#[serde(rename_all = "kebab-case")]
+pub struct InstallConfig {
+    product_name: String,
+    product_version: String,
+    port: u16,
+    #[serde(default)]
+    keystore: KeystoreConfig,
+    #[serde(
+        default = "default_install_config_context_path",
+        deserialize_with = "deserialize_install_config_context_path"
+    )]
+    context_path: String,
+    #[serde(default = "default_install_config_use_console_log")]
+    use_console_log: bool,
+    #[serde(default)]
+    server: ServerConfig,
+}
+
+impl AsRef<InstallConfig> for InstallConfig {
+    #[inline]
+    fn as_ref(&self) -> &InstallConfig {
+        self
+    }
+}
+
+impl InstallConfig {
+    /// Returns the service's name.
+    ///
+    /// Required.
+    #[inline]
+    pub fn product_name(&self) -> &str {
+        &self.product_name
+    }
+
+    /// Returns the service's version.
+    ///
+    /// Required.
+    #[inline]
+    pub fn product_version(&self) -> &str {
+        &self.product_version
+    }
+
+    /// Returns the port the server will listen on.
+    ///
+    /// Required.
+    #[inline]
+    pub fn port(&self) -> u16 {
+        self.port
+    }
+
+    /// Returns the server's TLS key configuration.
+    #[inline]
+    pub fn keystore(&self) -> &KeystoreConfig {
+        &self.keystore
+    }
+
+    /// Returns the server's context path.
+    ///
+    /// This must either be equal to `/` or start but not end with a `/`.
+    ///
+    /// Defaults to `/`.
+    #[inline]
+    pub fn context_path(&self) -> &str {
+        &self.context_path
+    }
+
+    /// If `true`, the server will log to standard output rather than to files.
+    ///
+    /// Defaults to `true` if running in a container and false otherwise.
+    #[inline]
+    pub fn use_console_log(&self) -> bool {
+        self.use_console_log
+    }
+
+    /// Returns advanced server settings.
+    #[inline]
+    pub fn server(&self) -> &ServerConfig {
+        &self.server
+    }
+}
+
+#[inline]
+fn default_install_config_context_path() -> String {
+    "/".to_string()
+}
+
+#[inline]
+fn deserialize_install_config_context_path<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let context_path = String::deserialize(deserializer)?;
+    if !(context_path == "/" || (context_path.starts_with('/') && !context_path.ends_with('/'))) {
+        return Err(de::Error::invalid_value(
+            de::Unexpected::Str(&context_path),
+            &"a valid context path",
+        ));
+    }
+
+    Ok(context_path)
+}
+
+#[inline]
+fn default_install_config_use_console_log() -> bool {
+    env::var_os("CONTAINER").is_some()
+}
+
+/// TLS key configuration.
+#[derive(Deserialize, Clone, PartialEq, Debug)]
+#[serde(default, rename_all = "kebab-case")]
+pub struct KeystoreConfig {
+    key_path: PathBuf,
+    cert_path: PathBuf,
+}
+
+impl KeystoreConfig {
+    /// Returns the path to the server's PEM-encoded private key.
+    ///
+    /// Defaults to `var/security/key.pem`.
+    #[inline]
+    pub fn key_path(&self) -> &Path {
+        &self.key_path
+    }
+
+    /// Returns the path to the server's PEM-encoded certificate chain.
+    ///
+    /// The file should contain a sequence of certificates starting with the leaf certificate corresponding to the key
+    /// in [`Self::key_path`] followed by the rest of the certificate chain up to a trusted root.
+    ///
+    /// Defaults to `var/security/cert.cer`.
+    #[inline]
+    pub fn cert_path(&self) -> &Path {
+        &self.cert_path
+    }
+}
+
+impl Default for KeystoreConfig {
+    #[inline]
+    fn default() -> Self {
+        KeystoreConfig {
+            key_path: PathBuf::from("var/security/key.pem"),
+            cert_path: PathBuf::from("var/security/cert.cer"),
+        }
+    }
+}
+
+/// Advanced server configuration.
+#[derive(Deserialize, Clone, PartialEq, Debug)]
+#[serde(default, rename_all = "kebab-case")]
+pub struct ServerConfig {
+    processors: usize,
+    min_threads: Option<usize>,
+    max_threads: Option<usize>,
+    max_connections: Option<usize>,
+    io_threads: Option<usize>,
+    #[serde(with = "humantime_serde")]
+    idle_thread_timeout: Duration,
+    shutdown_timeout: Duration,
+    gzip: bool,
+    http2: bool,
+    #[serde(with = "humantime_serde")]
+    idle_connection_timeout: Option<Duration>,
+}
+
+impl Default for ServerConfig {
+    #[inline]
+    fn default() -> Self {
+        ServerConfig {
+            processors: num_cpus::get(),
+            min_threads: None,
+            max_threads: None,
+            max_connections: None,
+            io_threads: None,
+            idle_thread_timeout: Duration::from_secs(5 * 60),
+            shutdown_timeout: Duration::from_secs(15),
+            gzip: true,
+            http2: false,
+            idle_connection_timeout: None,
+        }
+    }
+}
+
+impl ServerConfig {
+    /// Returns the number of processors the server is allocated.
+    ///
+    /// This is only used to derive default values for other settings in this type.
+    ///
+    /// Defaults to the number of logical CPUs.
+    #[inline]
+    pub fn processors(&self) -> usize {
+        self.processors
+    }
+
+    /// Returns the minimum number of threads in the pool used to process blocking endpoints.
+    ///
+    /// Defaults to 8 times the number of processors.
+    #[inline]
+    pub fn min_threads(&self) -> usize {
+        self.min_threads.unwrap_or_else(|| self.processors * 8)
+    }
+
+    /// Returns the maximum number of threads in the pool used to process blocking endpoints.
+    ///
+    /// Defaults to the maximum of 32 times the number of processors and 256.
+    #[inline]
+    pub fn max_threads(&self) -> usize {
+        self.max_threads
+            .unwrap_or_else(|| usize::max(self.processors * 32, 256))
+    }
+
+    /// Returns the maximum number of live TCP connections the server will allow at any time.
+    ///
+    /// Defaults to 10 times the value of [`Self::max_threads`].
+    #[inline]
+    pub fn max_connections(&self) -> usize {
+        self.max_connections
+            .unwrap_or_else(|| self.max_threads() * 10)
+    }
+
+    /// Returns the number of threads used for nonblocking operations in the server's Tokio runtime.
+    ///
+    /// Defaults to half the number of processors.
+    #[inline]
+    pub fn io_threads(&self) -> usize {
+        self.io_threads
+            .unwrap_or_else(|| usize::max(1, self.processors / 2))
+    }
+
+    /// Returns the amount of time a thread in the blocking request pool will sit idle before shutting down.
+    ///
+    /// Defaults to 5 minutes.
+    #[inline]
+    pub fn idle_thread_timeout(&self) -> Duration {
+        self.idle_thread_timeout
+    }
+
+    /// Returns the amount of time the server will wait for pending requests to complete when shutting down.
+    ///
+    /// Defaults to 15 seconds.
+    #[inline]
+    pub fn shutdown_timeout(&self) -> Duration {
+        self.shutdown_timeout
+    }
+
+    /// Determines if responses larger than 1 MiB will be compressed with gzip.
+    ///
+    /// Defaults to `true`.
+    #[inline]
+    pub fn gzip(&self) -> bool {
+        self.gzip
+    }
+
+    /// Determines if the server will support the HTTP2 protocol.
+    ///
+    /// Defaults to `false`.
+    #[inline]
+    pub fn http2(&self) -> bool {
+        self.http2
+    }
+
+    /// Returns the amount of time the server allows TCP connections to remain idle before shutting them down.
+    ///
+    /// If `None`, defaults to 1 minute. If `Some`, the time will be included in HTTP responses in a `Keep-Alive`
+    /// header.
+    #[inline]
+    pub fn idle_connection_timeout(&self) -> Option<Duration> {
+        self.idle_connection_timeout
+    }
+}

--- a/witchcraft-server-config/src/lib.rs
+++ b/witchcraft-server-config/src/lib.rs
@@ -1,0 +1,17 @@
+// Copyright 2021 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//! Witchcraft server configuration.
+#![warn(missing_docs)]
+pub mod install;
+pub mod runtime;

--- a/witchcraft-server-config/src/runtime.rs
+++ b/witchcraft-server-config/src/runtime.rs
@@ -1,0 +1,164 @@
+// Copyright 2021 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//! Runtime-reloadable configuration.
+use conjure_runtime_config::ServicesConfig;
+use serde::de;
+use serde::{Deserialize, Deserializer};
+use std::collections::HashMap;
+use witchcraft_log::LevelFilter;
+
+/// The runtime-reloadable configuration for a Witchcraft server.
+#[derive(Deserialize, Clone, PartialEq, Debug)]
+#[serde(rename_all = "kebab-case")]
+pub struct RuntimeConfig {
+    diagnostics: DiagnosticsConfig,
+    health_checks: HealthChecksConfig,
+    #[serde(default)]
+    logging: LoggingConfig,
+    #[serde(default)]
+    service_discovery: ServicesConfig,
+}
+
+impl AsRef<RuntimeConfig> for RuntimeConfig {
+    #[inline]
+    fn as_ref(&self) -> &RuntimeConfig {
+        self
+    }
+}
+
+impl RuntimeConfig {
+    /// Returns the server's diagnostics configuration.
+    ///
+    /// Required.
+    #[inline]
+    pub fn diagnostics(&self) -> &DiagnosticsConfig {
+        &self.diagnostics
+    }
+
+    /// Returns the server's health checks configuration.
+    ///
+    /// Required.
+    #[inline]
+    pub fn health_checks(&self) -> &HealthChecksConfig {
+        &self.health_checks
+    }
+
+    /// Returns the server's logging configuration.
+    #[inline]
+    pub fn logging(&self) -> &LoggingConfig {
+        &self.logging
+    }
+
+    /// Returns the server's service discovery configuration.
+    #[inline]
+    pub fn service_discovery(&self) -> &ServicesConfig {
+        &self.service_discovery
+    }
+}
+
+/// Diagnostics configuration.
+#[derive(Deserialize, Clone, PartialEq, Debug)]
+#[serde(rename_all = "kebab-case")]
+pub struct DiagnosticsConfig {
+    debug_shared_secret: String,
+}
+
+impl DiagnosticsConfig {
+    /// Returns the shared secret used to authorize requests to the server's debug endpoint.
+    ///
+    /// Required.
+    #[inline]
+    pub fn debug_shared_secret(&self) -> &str {
+        &self.debug_shared_secret
+    }
+}
+
+/// Health checks configuration.
+#[derive(Deserialize, Clone, PartialEq, Debug)]
+#[serde(rename_all = "kebab-case")]
+pub struct HealthChecksConfig {
+    shared_secret: String,
+}
+
+impl HealthChecksConfig {
+    /// Returns the shared secret used to authorize requests to the server's health check endpoint.
+    #[inline]
+    pub fn shared_secret(&self) -> &str {
+        &self.shared_secret
+    }
+}
+
+/// Logging configuration.
+#[derive(Deserialize, Clone, PartialEq, Debug)]
+#[serde(default, rename_all = "kebab-case")]
+pub struct LoggingConfig {
+    level: LevelFilter,
+    loggers: HashMap<String, LevelFilter>,
+    #[serde(deserialize_with = "de_logging_config_tracing_rate")]
+    trace_rate: f32,
+}
+
+impl Default for LoggingConfig {
+    #[inline]
+    fn default() -> Self {
+        LoggingConfig {
+            level: LevelFilter::Info,
+            loggers: HashMap::new(),
+            trace_rate: 0.0005,
+        }
+    }
+}
+
+#[inline]
+fn de_logging_config_tracing_rate<'de, D>(deserializer: D) -> Result<f32, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let rate = f32::deserialize(deserializer)?;
+    if !(0.0..=1.0).contains(&rate) {
+        return Err(de::Error::invalid_value(
+            de::Unexpected::Float(f64::from(rate)),
+            &"valid rate",
+        ));
+    }
+
+    Ok(rate)
+}
+
+impl LoggingConfig {
+    /// Returns the logging verbosity filter applied globally for all service logs.
+    ///
+    /// Defaults to [`LevelFilter::Info`].
+    #[inline]
+    pub fn level(&self) -> LevelFilter {
+        self.level
+    }
+
+    /// Returns a map of verbosity filter overides applied to specific targets.
+    #[inline]
+    pub fn loggers(&self) -> &HashMap<String, LevelFilter> {
+        &self.loggers
+    }
+
+    /// Returns the rate at which new traces will be sampled between 0 and 1, inclusive.
+    ///
+    /// This only applies to fresh traces - Witchcraft will respect sampling decisions made by upstream services for a
+    /// given request.
+    ///
+    /// Defaults to 0.05%.
+    #[inline]
+    pub fn trace_rate(&self) -> f32 {
+        self.trace_rate
+    }
+}

--- a/witchcraft-server/Cargo.toml
+++ b/witchcraft-server/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "witchcraft-server"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+serde = "1"
+
+witchcraft-server-config = { path = "../witchcraft-server-config" }

--- a/witchcraft-server/src/lib.rs
+++ b/witchcraft-server/src/lib.rs
@@ -1,0 +1,55 @@
+// Copyright 2021 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//! A highly opinionated embedded application server for RESTy APIs.
+//!
+//! # Configuration
+//!
+//! The configuration for a Witchcraft server is split into two files. `install.yml` contains the configuration that is
+//! fixed at server startup, and `runtime.yml` contains the configuration that can be updated dynamically at runtime.
+//! These are deserialized into Rust types via the [`serde::Deserialize`] trait. Witchcraft's own internal configuration
+//! is represented by the [`InstallConfig`] and [`RuntimeConfig`] types. Services that need their own configuration
+//! should embed the Witchcraft configuration within their own using the `#[serde(flatten)]` annotation and implement
+//! the [`AsRef`] trait:
+//!
+//! ```
+//! use serde::Deserialize;
+//! use witchcraft_server::config::install::InstallConfig;
+//!
+//! #[derive(Deserialize)]
+//! #[serde(rename_all = "kebab-case")]
+//! struct MyInstallConfig {
+//!     shave_yaks: bool,
+//!     #[serde(flatten)]
+//!     base: InstallConfig,
+//! }
+//!
+//! impl AsRef<InstallConfig> for MyInstallConfig {
+//!     fn as_ref(&self) -> &InstallConfig {
+//!         &self.base
+//!     }
+//! }
+//! ```
+//!
+//! The service's custom configuration will then sit next to the standard Witchcraft configuration in `install.yml`:
+//!
+//! ```yml
+//! product-name: my-service
+//! product-version: 1.0.0
+//! port: 12345
+//! shave-yaks: true
+//! ```
+#![warn(missing_docs)]
+
+#[doc(inline)]
+pub use witchcraft_server_config as config;


### PR DESCRIPTION
This adds the base configuration types for a Witchcraft server's install.yml and runtime.yml. The layout is designed to follow our existing Java and Go Witchcraft config layouts, meaning it is significantly different from our current internal Rust server implementation.

Additionally, we're using a new method to allow server implementations to extend the base configuration. Rather than defining traits that return all of the required config values, we instead use the `#[serde(flatten)]` annotation to allow implementations to embed the base config along side their custom config. An example is in the crate-level documentation for `witchcraft-server`.

One downside of this approach is that due to the way `#[serde(flatten)]` is implemented, utilities like serde-ignored and serde-path-to-error will not work for any keys in the base server configuration. We may be able to fix that in the future, but I feel that overall it's worth sacrificing those diagnostics for a much less weird method for implementations to be able to extend the base configuration.