### PR TITLE
[8/n] Add core process metrics

### DIFF
--- a/witchcraft-server/Cargo.toml
+++ b/witchcraft-server/Cargo.toml
@@ -3,6 +3,10 @@ name = "witchcraft-server"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+default = ["jemalloc"]
+jemalloc = ["tikv-jemalloc-ctl", "tikv-jemallocator"]
+
 [dependencies]
 arc-swap = "1"
 async-compression = { version = "0.3", features = ["tokio", "gzip"] }
@@ -16,8 +20,10 @@ futures-sink = "0.3"
 futures-util = "0.3"
 libc = "0.2"
 log = "0.4"
+num_cpus = "1"
 parking_lot = "0.11"
 pin-project = "1"
+procinfo = "0.4"
 rand = "0.8"
 refreshable = "1"
 regex = "1"
@@ -25,6 +31,12 @@ serde = "1"
 serde-encrypted-value = "0.4"
 serde_yaml = "0.8"
 sequence_trie = "0.3"
+tikv-jemalloc-ctl = { version = "0.4", features = ["use_std"], optional = true }
+tikv-jemallocator = { version = "0.4", features = [
+    "unprefixed_malloc_on_supported_platforms",
+    "background_threads",
+    "profiling",
+], optional = true }
 tokio = { version = "1", features = [
     "fs",
     "macros",

--- a/witchcraft-server/src/lib.rs
+++ b/witchcraft-server/src/lib.rs
@@ -75,6 +75,7 @@ pub use witchcraft_server_config as config;
 
 mod configs;
 mod logging;
+mod metrics;
 mod shutdown_hooks;
 mod witchcraft;
 
@@ -146,6 +147,8 @@ where
     ))?;
 
     info!("server starting");
+
+    metrics::init(&metrics);
 
     let host_metrics = Arc::new(HostMetricsRegistry::new());
 

--- a/witchcraft-server/src/metrics/jemalloc.rs
+++ b/witchcraft-server/src/metrics/jemalloc.rs
@@ -1,0 +1,22 @@
+// Copyright 2022 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+use tikv_jemalloc_ctl::{epoch, stats};
+use witchcraft_metrics::MetricRegistry;
+
+pub fn register_metrics(metrics: &MetricRegistry) {
+    metrics.gauge("process.heap", move || {
+        let _ = epoch::advance();
+        stats::allocated::read().unwrap_or(0)
+    });
+}

--- a/witchcraft-server/src/metrics/mod.rs
+++ b/witchcraft-server/src/metrics/mod.rs
@@ -1,0 +1,98 @@
+// Copyright 2022 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+use crate::metrics::rlimit::Rlimit;
+use crate::metrics::rusage::Rusage;
+use procinfo::pid;
+use std::time::Instant;
+use std::{fs, io, panic};
+use witchcraft_log::info;
+use witchcraft_metrics::MetricRegistry;
+
+#[cfg(feature = "jemalloc")]
+mod jemalloc;
+mod rlimit;
+mod rusage;
+
+pub fn init(metrics: &MetricRegistry) {
+    register_uptime_metric(metrics);
+    register_panic_metric(metrics);
+    register_rusage_metrics(metrics);
+    register_proc_metrics(metrics);
+    #[cfg(feature = "jemalloc")]
+    jemalloc::register_metrics(metrics);
+}
+
+fn register_uptime_metric(metrics: &MetricRegistry) {
+    let start = Instant::now();
+    metrics.gauge("process.uptime", move || start.elapsed().as_micros() as u64);
+}
+
+fn register_panic_metric(metrics: &MetricRegistry) {
+    let panics = metrics.counter("process.panics");
+    let hook = panic::take_hook();
+    panic::set_hook(Box::new(move |info| {
+        panics.inc();
+        hook(info)
+    }));
+}
+
+fn register_rusage_metrics(metrics: &MetricRegistry) {
+    metrics.gauge("process.user-time", || {
+        Rusage::get_self().map_or(0, |r| r.user_time().as_micros() as u64)
+    });
+    metrics.gauge("process.user-time.norm", || {
+        Rusage::get_self().map_or(0, |r| {
+            r.user_time().as_micros() as u64 / num_cpus::get() as u64
+        })
+    });
+    metrics.gauge("process.system-time", || {
+        Rusage::get_self().map_or(0, |r| r.system_time().as_micros() as u64)
+    });
+    metrics.gauge("process.system-time.norm", || {
+        Rusage::get_self().map_or(0, |r| {
+            r.system_time().as_micros() as u64 / num_cpus::get() as u64
+        })
+    });
+    metrics.gauge("process.blocks-read", || {
+        Rusage::get_self().map_or(0, |r| r.blocks_read())
+    });
+    metrics.gauge("process.blocks-written", || {
+        Rusage::get_self().map_or(0, |r| r.blocks_written())
+    });
+}
+
+fn register_proc_metrics(metrics: &MetricRegistry) {
+    if cfg!(not(target_os = "linux")) {
+        info!("skipping /proc metric registration since this isn't Linux");
+        return;
+    }
+
+    metrics.gauge("process.threads", || {
+        pid::stat_self().map_or(0, |s| s.num_threads)
+    });
+
+    metrics.gauge("process.filedescriptor", || filedescriptor().unwrap_or(0.));
+}
+
+fn filedescriptor() -> io::Result<f32> {
+    let mut files = 0;
+    for r in fs::read_dir("/proc/self/fd")? {
+        r?;
+        files += 1;
+    }
+
+    let max_files = Rlimit::nofile()?.cur();
+
+    Ok(files as f32 / max_files as f32)
+}

--- a/witchcraft-server/src/metrics/rlimit.rs
+++ b/witchcraft-server/src/metrics/rlimit.rs
@@ -1,0 +1,34 @@
+// Copyright 2022 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+use std::io;
+use std::mem::MaybeUninit;
+
+pub struct Rlimit(libc::rlimit);
+
+impl Rlimit {
+    pub fn nofile() -> io::Result<Self> {
+        unsafe {
+            let mut limit = MaybeUninit::uninit();
+            if libc::getrlimit(libc::RLIMIT_NOFILE, limit.as_mut_ptr()) != 0 {
+                return Err(io::Error::last_os_error());
+            }
+
+            Ok(Rlimit(limit.assume_init()))
+        }
+    }
+
+    pub fn cur(&self) -> u64 {
+        self.0.rlim_cur as u64
+    }
+}

--- a/witchcraft-server/src/metrics/rusage.rs
+++ b/witchcraft-server/src/metrics/rusage.rs
@@ -1,0 +1,53 @@
+// Copyright 2022 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+use std::io;
+use std::mem::MaybeUninit;
+use std::time::Duration;
+
+pub struct Rusage(libc::rusage);
+
+impl Rusage {
+    pub fn get_self() -> io::Result<Self> {
+        unsafe {
+            let mut rusage = MaybeUninit::uninit();
+            if libc::getrusage(libc::RUSAGE_SELF, rusage.as_mut_ptr()) != 0 {
+                return Err(io::Error::last_os_error());
+            }
+
+            Ok(Rusage(rusage.assume_init()))
+        }
+    }
+
+    pub fn user_time(&self) -> Duration {
+        Duration::new(
+            self.0.ru_utime.tv_sec as u64,
+            self.0.ru_utime.tv_usec as u32 * 1000,
+        )
+    }
+
+    pub fn system_time(&self) -> Duration {
+        Duration::new(
+            self.0.ru_stime.tv_sec as u64,
+            self.0.ru_stime.tv_usec as u32 * 1000,
+        )
+    }
+
+    pub fn blocks_read(&self) -> u64 {
+        self.0.ru_inblock as u64
+    }
+
+    pub fn blocks_written(&self) -> u64 {
+        self.0.ru_oublock as u64
+    }
+}


### PR DESCRIPTION
The metrics reported here are largely the same as the ones we report in our current internal implementation, with some metrics that haven't seemed useful dropped and some new ones added. In general, many match those produced by WC-Java via Tritium, but named `process.foo` rather than `jvm.foo`.