### PR TITLE
[9/n] Initial HTTP server setup

### DIFF
--- a/witchcraft-server/Cargo.toml
+++ b/witchcraft-server/Cargo.toml
@@ -18,9 +18,13 @@ conjure-serde = "0.7"
 foreign-types = "0.5"
 futures-sink = "0.3"
 futures-util = "0.3"
+http = "0.2"
+http-body = "0.4"
+hyper = { version = "0.14", features = ["http1", "http2", "server"] }
 libc = "0.2"
 log = "0.4"
 num_cpus = "1"
+openssl = "0.10"
 parking_lot = "0.11"
 pin-project = "1"
 procinfo = "0.4"
@@ -31,6 +35,7 @@ serde = "1"
 serde-encrypted-value = "0.4"
 serde_yaml = "0.8"
 sequence_trie = "0.3"
+socket2 = "0.4"
 tikv-jemalloc-ctl = { version = "0.4", features = ["use_std"], optional = true }
 tikv-jemallocator = { version = "0.4", features = [
     "unprefixed_malloc_on_supported_platforms",
@@ -44,6 +49,7 @@ tokio = { version = "1", features = [
     "signal",
     "time",
 ] }
+tokio-openssl = "0.6"
 tokio-util = "0.6"
 witchcraft-log = "0.3"
 witchcraft-metrics = "0.2"

--- a/witchcraft-server/src/server.rs
+++ b/witchcraft-server/src/server.rs
@@ -1,0 +1,56 @@
+// Copyright 2022 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+use crate::service::accept::AcceptService;
+use crate::service::handler::HandlerService;
+use crate::service::hyper::HyperService;
+use crate::service::idle_connection::IdleConnectionLayer;
+use crate::service::tls::TlsLayer;
+use crate::service::{Service, ServiceBuilder};
+use conjure_error::Error;
+use std::sync::Arc;
+use tokio::task;
+use witchcraft_log::debug;
+use witchcraft_server_config::install::InstallConfig;
+
+pub async fn start(config: &InstallConfig) -> Result<(), Error> {
+    // This service handles invididual HTTP requests, each running concurrently.
+    let request_service = ServiceBuilder::new().service(HandlerService);
+
+    // This layer handles invididual TCP connections, each running concurrently.
+    let handle_service = ServiceBuilder::new()
+        .layer(TlsLayer::new(config)?)
+        .layer(IdleConnectionLayer::new(config))
+        .service(HyperService::new(request_service));
+    let handle_service = Arc::new(handle_service);
+
+    // This layer produces TCP connections, running serially.
+    let accept_service = ServiceBuilder::new().service(AcceptService::new(config)?);
+
+    task::spawn(async move {
+        loop {
+            let socket = accept_service.call(()).await;
+
+            task::spawn({
+                let handle_service = handle_service.clone();
+                async move {
+                    if let Err(e) = handle_service.call(socket).await {
+                        debug!("http connection terminated", error: e);
+                    }
+                }
+            });
+        }
+    });
+
+    Ok(())
+}

--- a/witchcraft-server/src/service/accept.rs
+++ b/witchcraft-server/src/service/accept.rs
@@ -1,0 +1,134 @@
+// Copyright 2022 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+use crate::service::Service;
+use conjure_error::Error;
+use futures_util::ready;
+use pin_project::pin_project;
+use socket2::{Domain, SockAddr, SockRef, Socket, TcpKeepalive, Type};
+use std::future::Future;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use std::time::Duration;
+use std::{fs, io};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::time::{self, Sleep};
+use witchcraft_log::warn;
+use witchcraft_server_config::install::InstallConfig;
+
+// This is pretty arbitrary - I just copied it from some Cloudflare blog post.
+const TCP_KEEPALIVE: Duration = Duration::from_secs(3 * 60);
+
+/// The root service of the socket service stack which accept raw TCP connections.
+pub struct AcceptService {
+    listener: Arc<TcpListener>,
+}
+
+impl AcceptService {
+    pub fn new(config: &InstallConfig) -> Result<Self, Error> {
+        let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), config.port());
+
+        let listener =
+            Socket::new(Domain::IPV4, Type::STREAM, None).map_err(Error::internal_safe)?;
+        listener
+            .set_nonblocking(true)
+            .map_err(Error::internal_safe)?;
+        listener
+            .set_reuse_address(true)
+            .map_err(Error::internal_safe)?;
+        listener
+            .bind(&SockAddr::from(addr))
+            .map_err(Error::internal_safe)?;
+        listener.listen(somaxconn()).map_err(Error::internal_safe)?;
+
+        let listener = TcpListener::from_std(listener.into()).map_err(Error::internal_safe)?;
+
+        Ok(AcceptService {
+            listener: Arc::new(listener),
+        })
+    }
+}
+
+impl Service<()> for AcceptService {
+    type Response = TcpStream;
+
+    type Future = AcceptFuture;
+
+    fn call(&self, _: ()) -> Self::Future {
+        AcceptFuture {
+            listener: self.listener.clone(),
+            sleep: None,
+        }
+    }
+}
+
+#[pin_project]
+pub struct AcceptFuture {
+    listener: Arc<TcpListener>,
+    #[pin]
+    sleep: Option<Sleep>,
+}
+
+impl Future for AcceptFuture {
+    type Output = TcpStream;
+
+    fn poll(self: std::pin::Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let mut this = self.project();
+
+        loop {
+            if let Some(sleep) = this.sleep.as_mut().as_pin_mut() {
+                ready!(sleep.poll(cx));
+                this.sleep.set(None);
+            }
+
+            match ready!(this.listener.poll_accept(cx)) {
+                Ok((socket, _)) => match setup_socket(&socket) {
+                    Ok(()) => return Poll::Ready(socket),
+                    Err(e) => warn!("error configuring socket", error: Error::internal_safe(e)),
+                },
+                // There are 3 broad categories of error we can encounter from accept:
+                // 1. The call was interrupted due to a signal, and we should just retry. This won't normally happen if
+                //      SA_RESTART is set, but we shouldn't assume that's the case.
+                // 2. We hit a system resource limit. We want to wait a bit before retrying so we don't hot loop.
+                // 3. We hit some other error. This could be something we don't expect to be possible like the listener
+                //      socket being closed, or (on Linux) an error that the connection we're accepting entered into
+                //      before leaving the accept queue. We just want to log it and keep going.
+                Err(e) => match e.raw_os_error() {
+                    Some(libc::EINTR) => {}
+                    Some(libc::EMFILE | libc::ENFILE | libc::ENOBUFS | libc::ENOMEM) => {
+                        warn!(
+                            "hit resource limit accepting socket",
+                            error: Error::internal_safe(e),
+                        );
+                        this.sleep.set(Some(time::sleep(Duration::from_secs(1))));
+                    }
+                    _ => warn!("error accepting socket", error: Error::internal_safe(e)),
+                },
+            }
+        }
+    }
+}
+
+fn somaxconn() -> i32 {
+    fs::read_to_string("/proc/sys/net/core/somaxconn")
+        .ok()
+        .and_then(|s| s.trim().parse::<i32>().ok())
+        .unwrap_or(128)
+}
+
+fn setup_socket(stream: &TcpStream) -> io::Result<()> {
+    stream.set_nodelay(true)?;
+    SockRef::from(stream).set_tcp_keepalive(&TcpKeepalive::new().with_time(TCP_KEEPALIVE))?;
+    Ok(())
+}

--- a/witchcraft-server/src/service/handler.rs
+++ b/witchcraft-server/src/service/handler.rs
@@ -1,0 +1,80 @@
+// Copyright 2022 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+use crate::service::Service;
+use bytes::Bytes;
+use futures_util::future::BoxFuture;
+use http::{HeaderMap, Request, Response, StatusCode};
+use http_body::combinators::BoxBody;
+use http_body::{Body, SizeHint};
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use std::{error, fmt};
+
+/// The terminal service in the handler stack which turns [`Request`]s into [`Response`]s.
+///
+/// It must be installed after routing.
+pub struct HandlerService;
+
+impl Service<Request<hyper::Body>> for HandlerService {
+    type Response = Response<BoxBody<Bytes, BodyWriteAborted>>;
+
+    type Future = BoxFuture<'static, Self::Response>;
+
+    fn call(&self, _req: Request<hyper::Body>) -> Self::Future {
+        let mut response = Response::new(EmptyBody.boxed());
+        *response.status_mut() = StatusCode::NOT_FOUND;
+        Box::pin(async move { response })
+    }
+}
+
+#[derive(Debug)]
+pub struct BodyWriteAborted;
+
+impl fmt::Display for BodyWriteAborted {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("body write aborted")
+    }
+}
+
+impl error::Error for BodyWriteAborted {}
+
+pub struct EmptyBody;
+
+impl Body for EmptyBody {
+    type Data = Bytes;
+
+    type Error = BodyWriteAborted;
+
+    fn poll_data(
+        self: Pin<&mut Self>,
+        _: &mut Context<'_>,
+    ) -> Poll<Option<Result<Self::Data, Self::Error>>> {
+        Poll::Ready(None)
+    }
+
+    fn poll_trailers(
+        self: Pin<&mut Self>,
+        _: &mut Context<'_>,
+    ) -> Poll<Result<Option<HeaderMap>, Self::Error>> {
+        Poll::Ready(Ok(None))
+    }
+
+    fn is_end_stream(&self) -> bool {
+        true
+    }
+
+    fn size_hint(&self) -> SizeHint {
+        SizeHint::with_exact(0)
+    }
+}

--- a/witchcraft-server/src/service/hyper.rs
+++ b/witchcraft-server/src/service/hyper.rs
@@ -1,0 +1,172 @@
+// Copyright 2022 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+use crate::service::{Layer, Service};
+use conjure_error::Error;
+use http::{Request, Response};
+use http_body::Body;
+use hyper::server::conn::{Connection, Http};
+use pin_project::pin_project;
+use std::error;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio_openssl::SslStream;
+
+pub struct NewConnection<S, L> {
+    pub stream: S,
+    pub layer: L,
+}
+
+pub trait GracefulShutdown {
+    fn graceful_shutdown(self: Pin<&mut Self>);
+}
+
+/// The bridge between the Witchcraft `Service` and Hyper's `Service`.
+pub struct HyperService<S> {
+    request_service: Arc<S>,
+}
+
+impl<S> HyperService<S> {
+    pub fn new(request_service: S) -> Self {
+        HyperService {
+            request_service: Arc::new(request_service),
+        }
+    }
+}
+
+impl<S, R, L, B> Service<NewConnection<SslStream<R>, L>> for HyperService<S>
+where
+    L: Layer<Arc<S>>,
+    L::Service: Service<Request<hyper::Body>, Response = Response<B>>,
+    <L::Service as Service<Request<hyper::Body>>>::Future: 'static + Send,
+    R: AsyncRead + AsyncWrite + Unpin + 'static,
+    B: Body + 'static + Send,
+    B::Data: Send,
+    B::Error: Into<Box<dyn error::Error + Sync + Send>>,
+{
+    type Response = Result<(), Error>;
+
+    type Future = HyperFuture<L::Service, SslStream<R>, B>;
+
+    fn call(&self, req: NewConnection<SslStream<R>, L>) -> Self::Future {
+        let mut http = Http::new();
+
+        if req.stream.ssl().selected_alpn_protocol() == Some(b"h2") {
+            http.http2_only(true);
+        } else {
+            http.http1_only(true).http1_half_close(false);
+        }
+
+        HyperFuture {
+            inner: http.serve_connection(
+                req.stream,
+                AdaptorService {
+                    inner: req.layer.layer(self.request_service.clone()),
+                },
+            ),
+        }
+    }
+}
+
+#[pin_project]
+pub struct HyperFuture<S, R, B>
+where
+    S: Service<Request<hyper::Body>, Response = Response<B>>,
+    B: Body,
+{
+    #[pin]
+    inner: Connection<R, AdaptorService<S>>,
+}
+
+impl<S, R, B> Future for HyperFuture<S, R, B>
+where
+    S: Service<Request<hyper::Body>, Response = Response<B>>,
+    S::Future: 'static + Send,
+    R: AsyncRead + AsyncWrite + Unpin + 'static,
+    B: Body + 'static + Send,
+    B::Data: Send,
+    B::Error: Into<Box<dyn error::Error + Sync + Send>>,
+{
+    type Output = Result<(), Error>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.project().inner.poll(cx).map_err(Error::internal_safe)
+    }
+}
+
+impl<S, R, B> GracefulShutdown for HyperFuture<S, R, B>
+where
+    S: Service<Request<hyper::Body>, Response = Response<B>>,
+    S::Future: 'static + Send,
+    R: AsyncRead + AsyncWrite + Unpin + 'static,
+    B: Body + 'static + Send,
+    B::Data: Send,
+    B::Error: Into<Box<dyn error::Error + Sync + Send>>,
+{
+    fn graceful_shutdown(self: Pin<&mut Self>) {
+        self.project().inner.graceful_shutdown()
+    }
+}
+
+struct AdaptorService<S> {
+    inner: S,
+}
+
+impl<S, R> hyper::service::Service<R> for AdaptorService<S>
+where
+    S: Service<R>,
+{
+    type Response = S::Response;
+
+    type Error = Void;
+
+    type Future = AdaptorFuture<S::Future>;
+
+    fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, req: R) -> Self::Future {
+        AdaptorFuture {
+            inner: self.inner.call(req),
+        }
+    }
+}
+
+pub enum Void {}
+
+impl From<Void> for Box<dyn error::Error + Sync + Send> {
+    fn from(void: Void) -> Self {
+        match void {}
+    }
+}
+
+#[pin_project]
+pub struct AdaptorFuture<F> {
+    #[pin]
+    inner: F,
+}
+
+impl<F, T> Future for AdaptorFuture<F>
+where
+    F: Future<Output = T>,
+{
+    type Output = Result<T, Void>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.project().inner.poll(cx).map(Ok)
+    }
+}

--- a/witchcraft-server/src/service/idle_connection.rs
+++ b/witchcraft-server/src/service/idle_connection.rs
@@ -1,0 +1,306 @@
+// Copyright 2022 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+use crate::service::hyper::{GracefulShutdown, NewConnection};
+use crate::service::{Layer, Service};
+use futures_util::ready;
+use http::{HeaderMap, Response};
+use http_body::Body;
+use parking_lot::Mutex;
+use pin_project::pin_project;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll, Waker};
+use std::time::Duration;
+use tokio::time::{self, Instant, Sleep};
+use witchcraft_server_config::install::InstallConfig;
+
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// A layer which triggers a graceful shutdown of connections that have been idle for a certain period of time.
+///
+/// The implementation is unfortunately somewhat tightly coupled to the hyper layer with the `NewConnection` type.
+pub struct IdleConnectionLayer {
+    idle_timeout: Duration,
+}
+
+impl IdleConnectionLayer {
+    pub fn new(config: &InstallConfig) -> Self {
+        IdleConnectionLayer {
+            idle_timeout: config
+                .server()
+                .idle_connection_timeout()
+                .unwrap_or(DEFAULT_TIMEOUT),
+        }
+    }
+}
+
+impl<S> Layer<S> for IdleConnectionLayer {
+    type Service = IdleConnectionService<S>;
+
+    fn layer(self, inner: S) -> Self::Service {
+        IdleConnectionService {
+            inner,
+            idle_timeout: self.idle_timeout,
+        }
+    }
+}
+
+pub struct IdleConnectionService<S> {
+    inner: S,
+    idle_timeout: Duration,
+}
+
+impl<S, R> Service<R> for IdleConnectionService<S>
+where
+    S: Service<NewConnection<R, RequestTrackerLayer>>,
+    S::Future: GracefulShutdown,
+{
+    type Response = S::Response;
+
+    type Future = IdleConnectionFuture<S::Future>;
+
+    fn call(&self, req: R) -> Self::Future {
+        let shared = Arc::new(Shared {
+            state: Mutex::new(State {
+                mode: Mode::Idle,
+                waker: None,
+                sleep: Box::pin(time::sleep(self.idle_timeout)),
+                idle_timeout: self.idle_timeout,
+            }),
+        });
+
+        IdleConnectionFuture {
+            inner: self.inner.call(NewConnection {
+                stream: req,
+                layer: RequestTrackerLayer {
+                    shared: shared.clone(),
+                },
+            }),
+            shared,
+        }
+    }
+}
+
+#[pin_project]
+pub struct IdleConnectionFuture<F> {
+    #[pin]
+    inner: F,
+    shared: Arc<Shared>,
+}
+
+impl<F> Future for IdleConnectionFuture<F>
+where
+    F: Future + GracefulShutdown,
+{
+    type Output = F::Output;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        if self.shared.poll_timed_out(cx).is_ready() {
+            self.as_mut().graceful_shutdown();
+        }
+
+        self.project().inner.poll(cx)
+    }
+}
+
+impl<F> GracefulShutdown for IdleConnectionFuture<F>
+where
+    F: GracefulShutdown,
+{
+    fn graceful_shutdown(self: Pin<&mut Self>) {
+        let this = self.project();
+
+        this.shared.graceful_shutdown();
+        this.inner.graceful_shutdown();
+    }
+}
+
+pub struct RequestTrackerLayer {
+    shared: Arc<Shared>,
+}
+
+impl<S> Layer<S> for RequestTrackerLayer {
+    type Service = RequestTrackerService<S>;
+
+    fn layer(self, inner: S) -> Self::Service {
+        RequestTrackerService {
+            inner,
+            shared: self.shared,
+        }
+    }
+}
+
+pub struct RequestTrackerService<S> {
+    inner: S,
+    shared: Arc<Shared>,
+}
+
+impl<S, R, B> Service<R> for RequestTrackerService<S>
+where
+    S: Service<R, Response = Response<B>>,
+{
+    type Response = Response<RequestTrackerBody<B>>;
+
+    type Future = RequestTrackerFuture<S::Future>;
+
+    fn call(&self, req: R) -> Self::Future {
+        self.shared.inc_active();
+
+        RequestTrackerFuture {
+            guard: Some(ActiveGuard {
+                shared: self.shared.clone(),
+            }),
+            inner: self.inner.call(req),
+        }
+    }
+}
+
+#[pin_project]
+pub struct RequestTrackerFuture<F> {
+    #[pin]
+    inner: F,
+    guard: Option<ActiveGuard>,
+}
+
+impl<F, B> Future for RequestTrackerFuture<F>
+where
+    F: Future<Output = Response<B>>,
+{
+    type Output = Response<RequestTrackerBody<B>>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        let response = ready!(this.inner.poll(cx));
+        let response = response.map(|inner| RequestTrackerBody {
+            inner,
+            _guard: this.guard.take().unwrap(),
+        });
+        Poll::Ready(response)
+    }
+}
+
+#[pin_project]
+pub struct RequestTrackerBody<B> {
+    #[pin]
+    inner: B,
+    _guard: ActiveGuard,
+}
+
+impl<B> Body for RequestTrackerBody<B>
+where
+    B: Body,
+{
+    type Data = B::Data;
+
+    type Error = B::Error;
+
+    fn poll_data(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Self::Data, Self::Error>>> {
+        self.project().inner.poll_data(cx)
+    }
+
+    fn poll_trailers(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<Option<HeaderMap>, Self::Error>> {
+        self.project().inner.poll_trailers(cx)
+    }
+
+    fn is_end_stream(&self) -> bool {
+        self.inner.is_end_stream()
+    }
+
+    fn size_hint(&self) -> http_body::SizeHint {
+        self.inner.size_hint()
+    }
+}
+
+struct ActiveGuard {
+    shared: Arc<Shared>,
+}
+
+impl Drop for ActiveGuard {
+    fn drop(&mut self) {
+        self.shared.dec_active();
+    }
+}
+
+enum Mode {
+    Active(usize),
+    Idle,
+    ShuttingDown,
+}
+
+struct State {
+    mode: Mode,
+    waker: Option<Waker>,
+    sleep: Pin<Box<Sleep>>,
+    idle_timeout: Duration,
+}
+
+struct Shared {
+    state: Mutex<State>,
+}
+
+impl Shared {
+    fn poll_timed_out(&self, cx: &mut Context<'_>) -> Poll<()> {
+        let mut state = self.state.lock();
+
+        if state
+            .waker
+            .as_ref()
+            .map_or(true, |waker| !cx.waker().will_wake(waker))
+        {
+            state.waker = Some(cx.waker().clone());
+        }
+
+        match state.mode {
+            Mode::Idle => state.sleep.as_mut().poll(cx),
+            _ => Poll::Pending,
+        }
+    }
+
+    fn graceful_shutdown(&self) {
+        self.state.lock().mode = Mode::ShuttingDown
+    }
+
+    fn inc_active(&self) {
+        let mut state = self.state.lock();
+
+        match &mut state.mode {
+            Mode::Active(num) => *num += 1,
+            Mode::Idle => state.mode = Mode::Active(1),
+            Mode::ShuttingDown => {}
+        }
+    }
+
+    fn dec_active(&self) {
+        let mut state = self.state.lock();
+
+        if let Mode::Active(num) = &mut state.mode {
+            *num -= 1;
+            if *num == 0 {
+                state.mode = Mode::Idle;
+                let deadline = Instant::now() + state.idle_timeout;
+                state.sleep.as_mut().reset(deadline);
+                if let Some(waker) = state.waker.take() {
+                    waker.wake();
+                }
+            }
+        }
+    }
+}

--- a/witchcraft-server/src/service/mod.rs
+++ b/witchcraft-server/src/service/mod.rs
@@ -1,0 +1,111 @@
+// Copyright 2022 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+use std::future::Future;
+use std::sync::Arc;
+
+pub mod accept;
+pub mod handler;
+pub mod hyper;
+pub mod idle_connection;
+pub mod tls;
+
+// This infrastructure is adapted from `tower`, with a few changes:
+//
+// * Layer::layer takes self by value.
+// * Service::Error has been removed.
+// * Service::poll_ready has been removed.
+// * Service::call takes self by shared reference rather than mutable reference.
+pub trait Layer<S> {
+    type Service;
+
+    fn layer(self, inner: S) -> Self::Service;
+}
+
+pub trait Service<R> {
+    type Response;
+
+    type Future: Future<Output = Self::Response>;
+
+    fn call(&self, req: R) -> Self::Future;
+}
+
+impl<S, R> Service<R> for Arc<S>
+where
+    S: ?Sized + Service<R>,
+{
+    type Response = S::Response;
+
+    type Future = S::Future;
+
+    #[inline]
+    fn call(&self, req: R) -> Self::Future {
+        (**self).call(req)
+    }
+}
+
+pub struct Identity;
+
+impl<S> Layer<S> for Identity {
+    type Service = S;
+
+    fn layer(self, inner: S) -> Self::Service {
+        inner
+    }
+}
+
+pub struct Stack<T, U> {
+    inner: U,
+    outer: T,
+}
+
+impl<T, U, S> Layer<S> for Stack<T, U>
+where
+    T: Layer<U::Service>,
+    U: Layer<S>,
+{
+    type Service = T::Service;
+
+    fn layer(self, inner: S) -> Self::Service {
+        let inner = self.inner.layer(inner);
+        self.outer.layer(inner)
+    }
+}
+
+pub struct ServiceBuilder<L> {
+    layer: L,
+}
+
+impl ServiceBuilder<Identity> {
+    pub fn new() -> Self {
+        ServiceBuilder { layer: Identity }
+    }
+}
+
+impl<L> ServiceBuilder<L> {
+    pub fn layer<T>(self, layer: T) -> ServiceBuilder<Stack<L, T>> {
+        ServiceBuilder {
+            layer: Stack {
+                inner: layer,
+                outer: self.layer,
+            },
+        }
+    }
+
+    pub fn service<S>(self, service: S) -> L::Service
+    where
+        L: Layer<S>,
+    {
+        self.layer.layer(service)
+    }
+}

--- a/witchcraft-server/src/service/tls.rs
+++ b/witchcraft-server/src/service/tls.rs
@@ -1,0 +1,196 @@
+// Copyright 2022 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+use crate::service::{Layer, Service};
+use conjure_error::Error;
+use futures_util::ready;
+use openssl::rand;
+use openssl::ssl::{
+    self, AlpnError, Ssl, SslContext, SslFiletype, SslMethod, SslOptions, SslVersion,
+};
+use pin_project::pin_project;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio_openssl::SslStream;
+use witchcraft_server_config::install::InstallConfig;
+
+const CIPHER_SUITES: &[&str] = &[
+    "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+    "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+    "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
+    "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384",
+    "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256",
+    "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+    "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+    "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
+    "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384",
+    "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
+];
+
+const TLS13_CIPHER_SUITES: &[&str] = &[
+    "TLS_AES_256_GCM_SHA384",
+    "TLS_AES_128_GCM_SHA256",
+    "TLS_CHACHA20_POLY1305_SHA256",
+];
+
+/// A layer which wraps streams in a TLS session.
+pub struct TlsLayer {
+    context: SslContext,
+}
+
+impl TlsLayer {
+    pub fn new(config: &InstallConfig) -> Result<Self, Error> {
+        let mut builder = SslContext::builder(SslMethod::tls()).map_err(Error::internal_safe)?;
+
+        builder
+            .set_certificate_chain_file(config.keystore().cert_path())
+            .map_err(Error::internal_safe)?;
+        builder
+            .set_private_key_file(config.keystore().key_path(), SslFiletype::PEM)
+            .map_err(Error::internal_safe)?;
+        builder.check_private_key().map_err(Error::internal_safe)?;
+
+        let cipher_list = convert_suites(CIPHER_SUITES);
+        builder
+            .set_cipher_list(&cipher_list)
+            .map_err(Error::internal_safe)?;
+
+        let ciphersuites = convert_suites(TLS13_CIPHER_SUITES);
+        builder
+            .set_ciphersuites(&ciphersuites)
+            .map_err(Error::internal_safe)?;
+
+        if config.server().http2() {
+            builder.set_alpn_select_callback(|_, client| {
+                ssl::select_next_proto(b"\x02h2\x08http/1.1", client).ok_or(AlpnError::ALERT_FATAL)
+            });
+        }
+
+        builder.set_options(SslOptions::CIPHER_SERVER_PREFERENCE);
+        builder
+            .set_min_proto_version(Some(SslVersion::TLS1_2))
+            .map_err(Error::internal_safe)?;
+        builder
+            .set_max_proto_version(Some(SslVersion::TLS1_3))
+            .map_err(Error::internal_safe)?;
+
+        let mut session_id_ctx = [0; 32];
+        rand::rand_bytes(&mut session_id_ctx).map_err(Error::internal_safe)?;
+        builder
+            .set_session_id_context(&session_id_ctx)
+            .map_err(Error::internal_safe)?;
+
+        Ok(TlsLayer {
+            context: builder.build(),
+        })
+    }
+}
+
+impl<S> Layer<S> for TlsLayer {
+    type Service = TlsService<S>;
+
+    fn layer(self, inner: S) -> Self::Service {
+        TlsService {
+            inner: Arc::new(inner),
+            context: self.context,
+        }
+    }
+}
+
+pub struct TlsService<S> {
+    inner: Arc<S>,
+    context: SslContext,
+}
+
+impl<S, R> Service<R> for TlsService<S>
+where
+    S: Service<SslStream<R>, Response = Result<(), Error>>,
+    R: AsyncRead + AsyncWrite + Unpin,
+{
+    type Response = S::Response;
+
+    type Future = TlsFuture<S, R>;
+
+    fn call(&self, req: R) -> Self::Future {
+        match Ssl::new(&self.context).and_then(|ssl| SslStream::new(ssl, req)) {
+            Ok(stream) => TlsFuture::Handshaking {
+                stream: Some(stream),
+                inner: self.inner.clone(),
+            },
+            Err(e) => TlsFuture::Error {
+                error: Some(Error::internal_safe(e)),
+            },
+        }
+    }
+}
+
+#[pin_project(project = TlsFutureProj)]
+pub enum TlsFuture<S, R>
+where
+    S: Service<SslStream<R>>,
+{
+    Handshaking {
+        stream: Option<SslStream<R>>,
+        inner: Arc<S>,
+    },
+    Inner {
+        #[pin]
+        future: S::Future,
+    },
+    Error {
+        error: Option<Error>,
+    },
+}
+
+impl<S, R> Future for TlsFuture<S, R>
+where
+    S: Service<SslStream<R>, Response = Result<(), Error>>,
+    R: AsyncRead + AsyncWrite + Unpin,
+{
+    type Output = Result<(), Error>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        loop {
+            match self.as_mut().project() {
+                TlsFutureProj::Handshaking { inner, stream } => {
+                    match ready!(Pin::new(stream.as_mut().unwrap()).poll_accept(cx)) {
+                        Ok(()) => {
+                            let stream = stream.take().unwrap();
+                            let new = TlsFuture::Inner {
+                                future: inner.call(stream),
+                            };
+                            self.set(new);
+                        }
+                        Err(e) => return Poll::Ready(Err(Error::internal_safe(e))),
+                    }
+                }
+                TlsFutureProj::Inner { future } => return future.poll(cx),
+                TlsFutureProj::Error { error } => return Poll::Ready(Err(error.take().unwrap())),
+            }
+        }
+    }
+}
+
+fn convert_suites(suites: &[&str]) -> String {
+    suites
+        .iter()
+        .filter_map(|s| match ssl::cipher_name(s) {
+            "(NONE)" => None,
+            s => Some(s),
+        })
+        .collect::<Vec<_>>()
+        .join(":")
+}


### PR DESCRIPTION
This adds the very basic core of the HTTP server - accepting connections, performing the TLS handshake, and responding to all HTTP requests with a 404.

The behavior should all match our internal implementation.