### PR TITLE
[19/n] Support TLS client auth

### DIFF
--- a/witchcraft-server-config/src/install.rs
+++ b/witchcraft-server-config/src/install.rs
@@ -26,6 +26,7 @@ pub struct InstallConfig {
     port: u16,
     #[serde(default)]
     keystore: KeystoreConfig,
+    client_auth_truststore: Option<ClientAuthTruststoreConfig>,
     #[serde(
         default = "default_install_config_context_path",
         deserialize_with = "deserialize_install_config_context_path"
@@ -73,6 +74,18 @@ impl InstallConfig {
     #[inline]
     pub fn keystore(&self) -> &KeystoreConfig {
         &self.keystore
+    }
+
+    /// Returns the server's TLS client authentication truststore configuration.
+    ///
+    /// If set, the server will request (but not require) the client to authenticate itself during the TLS handshake.
+    /// If a certificate is present and validated against the trust roots, all requests made over that connection will
+    /// include a `ClientCertificate` extension.
+    ///
+    /// Defaults to `None`.
+    #[inline]
+    pub fn client_auth_truststore(&self) -> Option<&ClientAuthTruststoreConfig> {
+        self.client_auth_truststore.as_ref()
     }
 
     /// Returns the server's context path.
@@ -161,6 +174,33 @@ impl Default for KeystoreConfig {
         KeystoreConfig {
             key_path: PathBuf::from("var/security/key.pem"),
             cert_path: PathBuf::from("var/security/cert.cer"),
+        }
+    }
+}
+
+/// TLS client authentication configuration.
+#[derive(Deserialize, Clone, PartialEq, Debug)]
+#[serde(default, rename_all = "kebab-case")]
+pub struct ClientAuthTruststoreConfig {
+    path: PathBuf,
+}
+
+impl ClientAuthTruststoreConfig {
+    /// Returns the path to a file containg PEM-encoded certificates (i.e. blocks of `-----BEGIN CERTIFICATE-----`)
+    /// that will act as the trust roots for validating the client's identity.
+    ///
+    /// Defaults to `var/security/ca.cer`.
+    #[inline]
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Default for ClientAuthTruststoreConfig {
+    #[inline]
+    fn default() -> Self {
+        ClientAuthTruststoreConfig {
+            path: PathBuf::from("var/security/ca.cer"),
         }
     }
 }

--- a/witchcraft-server/Cargo.toml
+++ b/witchcraft-server/Cargo.toml
@@ -31,9 +31,8 @@ log = "0.4"
 num_cpus = "1"
 once_cell = "1"
 openssl = "0.10"
-parking_lot = "0.11"
+parking_lot = "0.12"
 pin-project = "1"
-procinfo = "0.4"
 rand = "0.8"
 refreshable = "1"
 regex = "1"
@@ -63,6 +62,9 @@ witchcraft-metrics = "0.2"
 zipkin = "0.4"
 
 witchcraft-server-config = { path = "../witchcraft-server-config" }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+procinfo = "0.4"
 
 [dev-dependencies]
 flate2 = "1"

--- a/witchcraft-server/src/lib.rs
+++ b/witchcraft-server/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2021 Palantir Technologies, Inc.
+// Copyright 2022 Palantir Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -80,6 +80,7 @@ mod metrics;
 mod server;
 mod service;
 mod shutdown_hooks;
+pub mod tls;
 mod witchcraft;
 
 /// Initializes a Witchcraft server.

--- a/witchcraft-server/src/metrics/proc.rs
+++ b/witchcraft-server/src/metrics/proc.rs
@@ -11,10 +11,32 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-use std::io;
+use procinfo::pid;
 use std::mem::MaybeUninit;
+use std::{fs, io};
+use witchcraft_metrics::MetricRegistry;
 
-pub struct Rlimit(libc::rlimit);
+pub fn register_metrics(metrics: &MetricRegistry) {
+    metrics.gauge("process.threads", || {
+        pid::stat_self().map_or(0, |s| s.num_threads)
+    });
+
+    metrics.gauge("process.filedescriptor", || filedescriptor().unwrap_or(0.));
+}
+
+fn filedescriptor() -> io::Result<f32> {
+    let mut files = 0;
+    for r in fs::read_dir("/proc/self/fd")? {
+        r?;
+        files += 1;
+    }
+
+    let max_files = Rlimit::nofile()?.cur();
+
+    Ok(files as f32 / max_files as f32)
+}
+
+struct Rlimit(libc::rlimit);
 
 impl Rlimit {
     pub fn nofile() -> io::Result<Self> {

--- a/witchcraft-server/src/service/client_certificate.rs
+++ b/witchcraft-server/src/service/client_certificate.rs
@@ -1,0 +1,94 @@
+// Copyright 2022 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+use crate::service::hyper::NewConnection;
+use crate::service::{Layer, Service, Stack};
+use crate::tls::ClientCertificate;
+use http::Request;
+use tokio_openssl::SslStream;
+
+/// A layer which injects a [`ClientCertificate`] extension into all requests made over the connection.
+pub struct ClientCertificateLayer;
+
+impl<S> Layer<S> for ClientCertificateLayer {
+    type Service = ClientCertificateService<S>;
+
+    fn layer(self, inner: S) -> Self::Service {
+        ClientCertificateService { inner }
+    }
+}
+
+pub struct ClientCertificateService<S> {
+    inner: S,
+}
+
+impl<S, T, L> Service<NewConnection<SslStream<T>, L>> for ClientCertificateService<S>
+where
+    S: Service<NewConnection<SslStream<T>, Stack<L, ClientCertificateRequestLayer>>>,
+{
+    type Response = S::Response;
+
+    type Future = S::Future;
+
+    fn call(&self, req: NewConnection<SslStream<T>, L>) -> Self::Future {
+        let cert = req
+            .stream
+            .ssl()
+            .peer_certificate()
+            .map(ClientCertificate::new);
+
+        self.inner.call(NewConnection {
+            stream: req.stream,
+            service_builder: req
+                .service_builder
+                .layer(ClientCertificateRequestLayer { cert }),
+        })
+    }
+}
+
+pub struct ClientCertificateRequestLayer {
+    cert: Option<ClientCertificate>,
+}
+
+impl<S> Layer<S> for ClientCertificateRequestLayer {
+    type Service = ClientCertificateRequestService<S>;
+
+    fn layer(self, inner: S) -> Self::Service {
+        ClientCertificateRequestService {
+            inner,
+            cert: self.cert,
+        }
+    }
+}
+
+pub struct ClientCertificateRequestService<S> {
+    inner: S,
+    cert: Option<ClientCertificate>,
+}
+
+impl<S, B> Service<Request<B>> for ClientCertificateRequestService<S>
+where
+    S: Service<Request<B>>,
+{
+    type Response = S::Response;
+
+    type Future = S::Future;
+
+    fn call(&self, mut req: Request<B>) -> Self::Future {
+        if let Some(cert) = &self.cert {
+            req.extensions_mut().insert(cert.clone());
+        }
+
+        self.inner.call(req)
+    }
+}

--- a/witchcraft-server/src/service/hyper.rs
+++ b/witchcraft-server/src/service/hyper.rs
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-use crate::service::{Layer, Service};
+use crate::service::{Layer, Service, ServiceBuilder};
 use conjure_error::Error;
 use http::{Request, Response};
 use http_body::Body;
@@ -27,7 +27,7 @@ use tokio_openssl::SslStream;
 
 pub struct NewConnection<S, L> {
     pub stream: S,
-    pub layer: L,
+    pub service_builder: ServiceBuilder<L>,
 }
 
 pub trait GracefulShutdown {
@@ -74,7 +74,7 @@ where
             inner: http.serve_connection(
                 req.stream,
                 AdaptorService {
-                    inner: req.layer.layer(self.request_service.clone()),
+                    inner: req.service_builder.service(self.request_service.clone()),
                 },
             ),
         }

--- a/witchcraft-server/src/service/mod.rs
+++ b/witchcraft-server/src/service/mod.rs
@@ -16,6 +16,7 @@ use std::sync::Arc;
 
 pub mod accept;
 pub mod catch_unwind;
+pub mod client_certificate;
 pub mod connection_limit;
 pub mod connection_metrics;
 pub mod deprecation_header;

--- a/witchcraft-server/src/tls/client_certificate.rs
+++ b/witchcraft-server/src/tls/client_certificate.rs
@@ -1,0 +1,34 @@
+// Copyright 2022 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+use openssl::x509::{X509Ref, X509};
+
+/// A client's identity provided during the TLS handshake.
+///
+/// If client authentication is enabled and a client provides a certificate during the TLS handshake, this will be added
+/// to the extensions of each request made on that connection.
+#[derive(Clone)]
+pub struct ClientCertificate {
+    cert: X509,
+}
+
+// FIXME(sfackler) what accessors should we expose here? We probably want to avoid exposing `openssl` APIs directly.
+impl ClientCertificate {
+    pub(crate) fn new(cert: X509) -> Self {
+        ClientCertificate { cert }
+    }
+
+    pub(crate) fn x509(&self) -> &X509Ref {
+        &self.cert
+    }
+}

--- a/witchcraft-server/src/tls/mod.rs
+++ b/witchcraft-server/src/tls/mod.rs
@@ -1,0 +1,19 @@
+// Copyright 2022 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//! Advanced TLS features.
+pub use client_certificate::ClientCertificate;
+pub use tls_client_authentication::TlsClientAuthenticationService;
+
+mod client_certificate;
+mod tls_client_authentication;

--- a/witchcraft-server/src/tls/tls_client_authentication.rs
+++ b/witchcraft-server/src/tls/tls_client_authentication.rs
@@ -1,0 +1,208 @@
+// Copyright 2022 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+use crate::tls::ClientCertificate;
+use async_trait::async_trait;
+use conjure_error::{Error, PermissionDenied};
+use conjure_http::server::{
+    AsyncEndpoint, AsyncResponseBody, AsyncService, Endpoint, EndpointMetadata, PathSegment,
+    ResponseBody, Service,
+};
+use conjure_http::SafeParams;
+use http::{Method, Request, Response};
+use openssl::nid::Nid;
+use openssl::stack::Stack;
+use openssl::x509::{GeneralName, X509NameRef};
+use refreshable::Refreshable;
+use std::collections::HashSet;
+use std::str;
+use std::sync::Arc;
+
+/// A service adapter which validates a client's certificate against a collection of allowed common names.
+///
+/// Requests will be rejected if the client did not provide a certificate or if the certificate does not have an allowed
+/// subject name. The validation logic prioritizes subject alternate name entries - the certificate's subject name will
+/// only be inspected if no SAN entries are present. Only DNSname entries are supported.
+pub struct TlsClientAuthenticationService<T> {
+    inner: T,
+    trusted_subject_names: Arc<Refreshable<HashSet<String>, Error>>,
+}
+
+impl<T, I, O> Service<I, O> for TlsClientAuthenticationService<T>
+where
+    T: Service<I, O>,
+    I: 'static,
+    O: 'static,
+{
+    fn endpoints(&self) -> Vec<Box<dyn Endpoint<I, O> + Sync + Send>> {
+        self.inner
+            .endpoints()
+            .into_iter()
+            .map(|inner| {
+                Box::new(TlsClientAuthenticationEndpoint {
+                    inner,
+                    trusted_subject_names: self.trusted_subject_names.clone(),
+                }) as _
+            })
+            .collect()
+    }
+}
+
+impl<T, I, O> AsyncService<I, O> for TlsClientAuthenticationService<T>
+where
+    T: AsyncService<I, O>,
+    I: 'static + Send,
+    O: 'static,
+{
+    fn endpoints(&self) -> Vec<Box<dyn AsyncEndpoint<I, O> + Sync + Send>> {
+        self.inner
+            .endpoints()
+            .into_iter()
+            .map(|inner| {
+                Box::new(TlsClientAuthenticationEndpoint {
+                    inner,
+                    trusted_subject_names: self.trusted_subject_names.clone(),
+                }) as _
+            })
+            .collect()
+    }
+}
+
+struct TlsClientAuthenticationEndpoint<T> {
+    inner: T,
+    trusted_subject_names: Arc<Refreshable<HashSet<String>, Error>>,
+}
+
+impl<T> TlsClientAuthenticationEndpoint<T> {
+    fn check_request<I>(&self, req: &Request<I>) -> Result<(), Error> {
+        let client_cert = match req.extensions().get::<ClientCertificate>() {
+            Some(client_cert) => client_cert,
+            None => {
+                return Err(Error::service_safe(
+                    "client did not provide a certificate",
+                    PermissionDenied::new(),
+                ))
+            }
+        };
+
+        let matches = match client_cert.x509().subject_alt_names() {
+            Some(sans) => self.check_subject_alternate_names(sans),
+            None => self.check_subject_name(client_cert.x509().subject_name()),
+        };
+
+        if matches {
+            Ok(())
+        } else {
+            Err(Error::service_safe(
+                "client certificate's subject name(s) not allowed",
+                PermissionDenied::new(),
+            ))
+        }
+    }
+
+    fn check_subject_alternate_names(&self, sans: Stack<GeneralName>) -> bool {
+        let trusted_subject_names = self.trusted_subject_names.get();
+
+        for san in sans {
+            let dnsname = match san.dnsname() {
+                Some(dnsname) => dnsname,
+                None => continue,
+            };
+
+            if trusted_subject_names.contains(dnsname) {
+                return true;
+            }
+        }
+
+        false
+    }
+
+    fn check_subject_name(&self, subject_name: &X509NameRef) -> bool {
+        let trusted_subject_names = self.trusted_subject_names.get();
+
+        for common_name in subject_name.entries_by_nid(Nid::COMMONNAME) {
+            let common_name = match str::from_utf8(common_name.data().as_slice()) {
+                Ok(common_name) => common_name,
+                Err(_) => continue,
+            };
+
+            if trusted_subject_names.contains(common_name) {
+                return true;
+            }
+        }
+
+        false
+    }
+}
+
+impl<T> EndpointMetadata for TlsClientAuthenticationEndpoint<T>
+where
+    T: EndpointMetadata,
+{
+    fn method(&self) -> Method {
+        self.inner.method()
+    }
+
+    fn path(&self) -> &[PathSegment] {
+        self.inner.path()
+    }
+
+    fn template(&self) -> &str {
+        self.inner.template()
+    }
+
+    fn service_name(&self) -> &str {
+        self.inner.service_name()
+    }
+
+    fn name(&self) -> &str {
+        self.inner.name()
+    }
+
+    fn deprecated(&self) -> Option<&str> {
+        self.inner.deprecated()
+    }
+}
+
+impl<T, I, O> Endpoint<I, O> for TlsClientAuthenticationEndpoint<T>
+where
+    T: Endpoint<I, O>,
+{
+    fn handle(
+        &self,
+        safe_params: &mut SafeParams,
+        req: Request<I>,
+    ) -> Result<Response<ResponseBody<O>>, Error> {
+        self.check_request(&req)?;
+        self.inner.handle(safe_params, req)
+    }
+}
+
+#[async_trait]
+impl<T, I, O> AsyncEndpoint<I, O> for TlsClientAuthenticationEndpoint<T>
+where
+    T: AsyncEndpoint<I, O> + Sync + Send,
+    I: Send,
+{
+    async fn handle(
+        &self,
+        safe_params: &mut SafeParams,
+        req: Request<I>,
+    ) -> Result<Response<AsyncResponseBody<O>>, Error>
+    where
+        I: 'async_trait,
+    {
+        self.check_request(&req)?;
+        self.inner.handle(safe_params, req).await
+    }
+}


### PR DESCRIPTION
Like WC-Java, if this is enabled we request but do not require the client to identify itself. If we do get a certificate, it's included as a request extension.

While extensions aren't exposed in Conjure-generated service handlers, developers can wrap their endpoint in an adaptor that checks the certificate before entering into the Conjure code. An example of that is the `TlsClientAuthenticationService` type.

This also changes the /proc metrics to only build on Linux since the procinfo crate appears to not compile on macOS.