### PR TITLE
[21/n] Support blocking Conjure endpoints

### DIFF
--- a/witchcraft-server/src/blocking/body.rs
+++ b/witchcraft-server/src/blocking/body.rs
@@ -1,0 +1,152 @@
+// Copyright 2022 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+use crate::body::ClientIo;
+use crate::server::RawBody;
+use bytes::{Buf, Bytes, BytesMut};
+use conjure_error::Error;
+use futures_channel::mpsc;
+use futures_util::SinkExt;
+use http_body::Body;
+use std::io::{BufRead, Read, Write};
+use std::{io, mem};
+use tokio::runtime::Handle;
+
+/// A streaming request body for blocking requests.
+pub struct RequestBody {
+    inner: RawBody,
+    handle: Handle,
+    cur: Bytes,
+}
+
+impl RequestBody {
+    pub(crate) fn new(inner: RawBody, handle: Handle) -> Self {
+        RequestBody {
+            inner,
+            handle,
+            cur: Bytes::new(),
+        }
+    }
+}
+
+impl Iterator for RequestBody {
+    type Item = Result<Bytes, Error>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.cur.has_remaining() {
+            return Some(Ok(mem::take(&mut self.cur)));
+        }
+
+        self.handle
+            .block_on(self.inner.data())
+            .map(|r| r.map_err(|e| Error::service_safe(e, ClientIo)))
+    }
+}
+
+impl Read for RequestBody {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let in_buf = self.fill_buf()?;
+        let len = usize::min(in_buf.len(), buf.len());
+        buf[..len].copy_from_slice(&in_buf[..len]);
+        self.consume(len);
+        Ok(len)
+    }
+}
+
+impl BufRead for RequestBody {
+    fn fill_buf(&mut self) -> io::Result<&[u8]> {
+        while self.cur.is_empty() {
+            match self
+                .handle
+                .block_on(self.inner.data())
+                .transpose()
+                .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?
+            {
+                Some(bytes) => self.cur = bytes,
+                None => break,
+            }
+        }
+
+        Ok(&self.cur)
+    }
+
+    fn consume(&mut self, amt: usize) {
+        self.cur.advance(amt)
+    }
+}
+
+pub enum BodyPart {
+    Data(Bytes),
+    Done,
+}
+
+/// The writer used for streaming response bodies of blocking endpoints.
+pub struct ResponseWriter {
+    sender: mpsc::Sender<BodyPart>,
+    handle: Handle,
+    buf: BytesMut,
+}
+
+impl ResponseWriter {
+    pub(crate) fn new(sender: mpsc::Sender<BodyPart>, handle: Handle) -> Self {
+        Self {
+            sender,
+            handle,
+            buf: BytesMut::new(),
+        }
+    }
+
+    fn flush_shallow(&mut self) -> io::Result<()> {
+        if self.buf.is_empty() {
+            return Ok(());
+        }
+
+        self.handle
+            .block_on(self.sender.feed(BodyPart::Data(self.buf.split().freeze())))
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+
+        Ok(())
+    }
+
+    pub(crate) fn finish(mut self) -> io::Result<()> {
+        self.flush()?;
+
+        self.handle
+            .block_on(self.sender.send(BodyPart::Done))
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+
+        Ok(())
+    }
+}
+
+impl Write for ResponseWriter {
+    #[inline]
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        if self.buf.len() > 4096 {
+            self.flush_shallow()?;
+        }
+
+        self.buf.extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.flush_shallow()?;
+
+        self.handle
+            .block_on(self.sender.flush())
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+
+        Ok(())
+    }
+}

--- a/witchcraft-server/src/blocking/conjure.rs
+++ b/witchcraft-server/src/blocking/conjure.rs
@@ -1,0 +1,261 @@
+// Copyright 2022 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+use crate::blocking::body::BodyPart;
+use crate::blocking::pool::ThreadPool;
+use crate::blocking::{RequestBody, ResponseWriter};
+use crate::body::ClientIo;
+use crate::endpoint::{errors, WitchcraftEndpoint};
+use crate::server::RawBody;
+use crate::service::endpoint_metrics::EndpointMetrics;
+use crate::service::handler::{BodyWriteAborted, EmptyBody};
+use async_trait::async_trait;
+use bytes::Bytes;
+use conjure_error::Error;
+use conjure_http::server::{self, Endpoint, EndpointMetadata, PathSegment, WriteBody};
+use conjure_http::SafeParams;
+use futures_channel::{mpsc, oneshot};
+use futures_util::Stream;
+use http::{HeaderMap, Method, Request, Response, StatusCode};
+use http_body::combinators::BoxBody;
+use http_body::{Body, SizeHint};
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use std::{mem, panic};
+use tokio::runtime::Handle;
+use witchcraft_log::{info, mdc};
+use witchcraft_metrics::MetricRegistry;
+use zipkin::TraceContext;
+
+/// A [`WitchcraftEndpoint`] wrapping a Conjure [`Endpoint`].
+pub struct ConjureBlockingEndpoint {
+    inner: Arc<dyn Endpoint<RequestBody, ResponseWriter> + Sync + Send>,
+    thread_pool: Arc<ThreadPool>,
+    metrics: EndpointMetrics,
+}
+
+impl ConjureBlockingEndpoint {
+    pub fn new(
+        metrics: &MetricRegistry,
+        thread_pool: &Arc<ThreadPool>,
+        inner: Box<dyn Endpoint<RequestBody, ResponseWriter> + Sync + Send>,
+    ) -> Self {
+        ConjureBlockingEndpoint {
+            metrics: EndpointMetrics::new(metrics, &inner),
+            inner: Arc::from(inner),
+            thread_pool: thread_pool.clone(),
+        }
+    }
+}
+
+impl EndpointMetadata for ConjureBlockingEndpoint {
+    fn method(&self) -> Method {
+        self.inner.method()
+    }
+
+    fn path(&self) -> &[PathSegment] {
+        self.inner.path()
+    }
+
+    fn template(&self) -> &str {
+        self.inner.template()
+    }
+
+    fn service_name(&self) -> &str {
+        self.inner.service_name()
+    }
+
+    fn name(&self) -> &str {
+        self.inner.name()
+    }
+
+    fn deprecated(&self) -> Option<&str> {
+        self.inner.deprecated()
+    }
+}
+
+#[async_trait]
+impl WitchcraftEndpoint for ConjureBlockingEndpoint {
+    fn metrics(&self) -> Option<&EndpointMetrics> {
+        Some(&self.metrics)
+    }
+
+    async fn handle(&self, req: Request<RawBody>) -> Response<BoxBody<Bytes, BodyWriteAborted>> {
+        let trace_context = zipkin::current();
+        let snapshot = mdc::snapshot();
+        let (sender, receiver) = oneshot::channel();
+        let endpoint = self.inner.clone();
+        let handle = Handle::current();
+
+        let blocking = move || {
+            let _guard = trace_context.map(zipkin::set_current);
+            mdc::set(snapshot);
+
+            let mut safe_params = SafeParams::new();
+            let req = req.map(|inner| RequestBody::new(inner, handle.clone()));
+
+            let mut response = endpoint.handle(&mut safe_params, req).unwrap_or_else(|e| {
+                errors::to_response(e, |o| {
+                    o.map_or(server::ResponseBody::Empty, server::ResponseBody::Fixed)
+                })
+            });
+
+            response.extensions_mut().insert(safe_params);
+
+            let (parts, body) = response.into_parts();
+            let (body, writer) = ResponseBody::new(body, handle);
+
+            let response = Response::from_parts(parts, body.boxed());
+            let _ = sender.send(response);
+
+            if let Some(writer) = writer {
+                if let Err(e) = writer.write_body() {
+                    info!("error writing streaming response body", error: e);
+                }
+            }
+        };
+
+        if self.thread_pool.try_execute(blocking).is_err() {
+            let mut response = Response::new(EmptyBody.boxed());
+            *response.status_mut() = StatusCode::SERVICE_UNAVAILABLE;
+            return response;
+        }
+
+        match receiver.await {
+            Ok(response) => response,
+            // If we don't get a response, the handler must have panicked. We don't actually care about the payload at
+            // this point (it's already been logged), so we just want to propagate a panic with an arbitrary payload to
+            // have the same panicking behavior as the async implementation.
+            Err(_canceled) => panic::resume_unwind(Box::new("")),
+        }
+    }
+}
+
+enum ResponseBody {
+    Empty,
+    Fixed(Bytes),
+    Streaming {
+        context_sender: Option<oneshot::Sender<Option<TraceContext>>>,
+        receiver: mpsc::Receiver<BodyPart>,
+    },
+}
+
+impl ResponseBody {
+    fn new(
+        body: server::ResponseBody<ResponseWriter>,
+        handle: Handle,
+    ) -> (Self, Option<StreamingWriter>) {
+        match body {
+            server::ResponseBody::Empty => (ResponseBody::Empty, None),
+            server::ResponseBody::Fixed(bytes) => (ResponseBody::Fixed(bytes), None),
+            server::ResponseBody::Streaming(writer) => {
+                let (context_sender, context_receiver) = oneshot::channel();
+                let (sender, receiver) = mpsc::channel(1);
+                (
+                    ResponseBody::Streaming {
+                        context_sender: Some(context_sender),
+                        receiver,
+                    },
+                    Some(StreamingWriter {
+                        context_receiver,
+                        sender,
+                        writer,
+                        handle,
+                    }),
+                )
+            }
+        }
+    }
+}
+
+impl Body for ResponseBody {
+    type Data = Bytes;
+
+    type Error = BodyWriteAborted;
+
+    fn poll_data(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Self::Data, Self::Error>>> {
+        match mem::replace(&mut *self, ResponseBody::Empty) {
+            ResponseBody::Empty => Poll::Ready(None),
+            ResponseBody::Fixed(bytes) => Poll::Ready(Some(Ok(bytes))),
+            ResponseBody::Streaming {
+                mut context_sender,
+                mut receiver,
+            } => {
+                if let Some(context_sender) = context_sender.take() {
+                    let _ = context_sender.send(zipkin::current());
+                }
+
+                let poll = match Pin::new(&mut receiver).poll_next(cx) {
+                    Poll::Pending => Poll::Pending,
+                    Poll::Ready(Some(BodyPart::Data(bytes))) => Poll::Ready(Some(Ok(bytes))),
+                    Poll::Ready(Some(BodyPart::Done)) => return Poll::Ready(None),
+                    Poll::Ready(None) => return Poll::Ready(Some(Err(BodyWriteAborted))),
+                };
+                *self = ResponseBody::Streaming {
+                    context_sender,
+                    receiver,
+                };
+
+                poll
+            }
+        }
+    }
+
+    fn poll_trailers(
+        self: Pin<&mut Self>,
+        _: &mut Context<'_>,
+    ) -> Poll<Result<Option<HeaderMap>, Self::Error>> {
+        Poll::Ready(Ok(None))
+    }
+
+    fn is_end_stream(&self) -> bool {
+        matches!(self, ResponseBody::Empty)
+    }
+
+    fn size_hint(&self) -> SizeHint {
+        match self {
+            ResponseBody::Empty => SizeHint::with_exact(0),
+            ResponseBody::Fixed(bytes) => SizeHint::with_exact(bytes.len() as u64),
+            ResponseBody::Streaming { .. } => SizeHint::new(),
+        }
+    }
+}
+
+struct StreamingWriter {
+    context_receiver: oneshot::Receiver<Option<TraceContext>>,
+    sender: mpsc::Sender<BodyPart>,
+    writer: Box<dyn WriteBody<ResponseWriter>>,
+    handle: Handle,
+}
+
+impl StreamingWriter {
+    fn write_body(self) -> Result<(), Error> {
+        let context = match self.handle.block_on(self.context_receiver) {
+            Ok(context) => context,
+            Err(e) => return Err(Error::service_safe(e, ClientIo)),
+        };
+        let _guard = context.map(zipkin::set_current);
+
+        let mut response_writer = ResponseWriter::new(self.sender, self.handle);
+        self.writer.write_body(&mut response_writer)?;
+        response_writer
+            .finish()
+            .map_err(|e| Error::service_safe(e, ClientIo))?;
+
+        Ok(())
+    }
+}

--- a/witchcraft-server/src/blocking/mod.rs
+++ b/witchcraft-server/src/blocking/mod.rs
@@ -1,0 +1,19 @@
+// Copyright 2022 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//! Blocking handler APIs.
+pub use body::{RequestBody, ResponseWriter};
+
+mod body;
+pub(crate) mod conjure;
+pub(crate) mod pool;

--- a/witchcraft-server/src/blocking/pool/job_queue.rs
+++ b/witchcraft-server/src/blocking/pool/job_queue.rs
@@ -1,0 +1,173 @@
+// Copyright 2022 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+use parking_lot::{Condvar, Mutex};
+use std::cell::UnsafeCell;
+use std::collections::VecDeque;
+use std::ptr;
+use std::time::Instant;
+
+struct Node {
+    cvar: Condvar,
+    next: *mut Node,
+    prev: *mut Node,
+}
+
+struct State<T> {
+    head: *mut Node,
+    jobs: VecDeque<T>,
+}
+
+unsafe impl<T> Sync for State<T> where T: Sync {}
+unsafe impl<T> Send for State<T> where T: Send {}
+
+/// A blocking queue that is "maximally unfair" to waiters.
+///
+/// That is, while jobs are processed FIFO, waiters are processed LIFO. This allows us to keep the number of threads in
+/// the pool to the minimum number required to keep up with the current request volume.
+///
+/// To make this happen, we unfortunately need to use a manual queueing implementation with intrusive lists rather than
+/// a simple Mutex + Condvar.
+pub struct JobQueue<T> {
+    state: Mutex<State<T>>,
+}
+
+impl<T> JobQueue<T> {
+    pub fn new() -> Self {
+        JobQueue {
+            state: Mutex::new(State {
+                head: ptr::null_mut(),
+                jobs: VecDeque::new(),
+            }),
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.state.lock().jobs.len()
+    }
+
+    pub fn push(&self, job: T) {
+        let mut state = self.state.lock();
+
+        state.jobs.push_back(job);
+
+        unsafe {
+            if !state.head.is_null() {
+                let woken = state.head;
+                state.head = (*woken).next;
+                if !state.head.is_null() {
+                    (*state.head).prev = ptr::null_mut();
+                }
+
+                (*woken).next = ptr::null_mut();
+                (*woken).cvar.notify_one();
+            }
+        }
+    }
+
+    pub fn try_pop(&self) -> Option<T> {
+        self.state.lock().jobs.pop_front()
+    }
+
+    pub fn pop_until(&self, timeout: Instant) -> Option<T> {
+        let mut state = self.state.lock();
+
+        loop {
+            if let Some(job) = state.jobs.pop_front() {
+                return Some(job);
+            }
+
+            let node = UnsafeCell::new(Node {
+                cvar: Condvar::new(),
+                next: state.head,
+                prev: ptr::null_mut(),
+            });
+
+            unsafe {
+                if !state.head.is_null() {
+                    (*state.head).prev = node.get();
+                }
+                state.head = node.get();
+
+                let result = (*node.get()).cvar.wait_until(&mut state, timeout);
+
+                if !(*node.get()).next.is_null() {
+                    (*(*node.get()).next).prev = (*node.get()).prev;
+                }
+
+                if !(*node.get()).prev.is_null() {
+                    (*(*node.get()).prev).next = (*node.get()).next;
+                } else if state.head == node.get() {
+                    state.head = (*node.get()).next;
+                }
+
+                if result.timed_out() {
+                    return None;
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::sync::Arc;
+    use std::thread;
+    use std::time::Duration;
+
+    #[test]
+    fn single_threaded() {
+        let queue = JobQueue::new();
+
+        queue.push(0);
+        assert_eq!(queue.try_pop(), Some(0));
+        assert_eq!(queue.try_pop(), None);
+
+        queue.push(1);
+        let start = Instant::now();
+        assert_eq!(queue.pop_until(start - Duration::from_millis(10)), Some(1));
+        let elapsed = start.elapsed();
+        assert!(elapsed < Duration::from_millis(10));
+
+        let start = Instant::now();
+        assert_eq!(queue.pop_until(start + Duration::from_millis(10)), None);
+        let elapsed = start.elapsed();
+        assert!(elapsed >= Duration::from_millis(10) && elapsed < Duration::from_millis(20));
+    }
+
+    #[test]
+    fn wake_lifo() {
+        let queue = Arc::new(JobQueue::<i32>::new());
+
+        let handle1 = thread::spawn({
+            let queue = queue.clone();
+            move || queue.pop_until(Instant::now() + Duration::from_millis(1500))
+        });
+
+        let handle2 = thread::spawn({
+            let queue = queue.clone();
+            move || {
+                thread::sleep(Duration::from_millis(100));
+                queue.pop_until(Instant::now() + Duration::from_millis(1500))
+            }
+        });
+
+        // wait for threads to get set up
+        thread::sleep(Duration::from_secs(1));
+        queue.push(0);
+
+        assert_eq!(handle1.join().unwrap(), None);
+        assert_eq!(handle2.join().unwrap(), Some(0));
+    }
+}

--- a/witchcraft-server/src/blocking/pool/mod.rs
+++ b/witchcraft-server/src/blocking/pool/mod.rs
@@ -1,0 +1,178 @@
+// Copyright 2022 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+use crate::blocking::pool::job_queue::JobQueue;
+use conjure_error::Error;
+use parking_lot::Mutex;
+use std::panic::{self, AssertUnwindSafe};
+use std::sync::Arc;
+use std::thread;
+use std::time::{Duration, Instant};
+use witchcraft_log::error;
+use witchcraft_metrics::MetricRegistry;
+use witchcraft_server_config::install::InstallConfig;
+
+mod job_queue;
+
+struct State {
+    threads: usize,
+    idle_threads: usize,
+    next_id: usize,
+}
+
+impl State {
+    fn active(&self) -> usize {
+        self.threads - self.idle_threads
+    }
+}
+
+struct Shared {
+    min_threads: usize,
+    max_threads: usize,
+    idle_timeout: Duration,
+    queue: JobQueue<Box<dyn FnOnce() + Send>>,
+    state: Mutex<State>,
+}
+
+impl Shared {
+    fn max(&self) -> usize {
+        self.max_threads
+    }
+
+    fn active(&self) -> usize {
+        self.state.lock().active()
+    }
+
+    fn utilization_max(&self) -> f64 {
+        let used = self.state.lock().active();
+        let available = self.max_threads;
+        used as f64 / available as f64
+    }
+
+    fn worker_loop(&self) {
+        while let Some(job) = self.get_job() {
+            let _ = panic::catch_unwind(AssertUnwindSafe(job));
+        }
+    }
+
+    fn get_job(&self) -> Option<Box<dyn FnOnce() + Send>> {
+        // fast path if there's a job ready
+        if let Some(job) = self.queue.try_pop() {
+            return Some(job);
+        }
+
+        let mut timeout = Instant::now() + self.idle_timeout;
+        let mut state = self.state.lock();
+        loop {
+            state.idle_threads += 1;
+            drop(state);
+            let r = self.queue.pop_until(timeout);
+            state = self.state.lock();
+            state.idle_threads -= 1;
+
+            match r {
+                Some(job) => return Some(job),
+                None => {
+                    if state.threads > self.min_threads {
+                        state.threads -= 1;
+                        return None;
+                    } else {
+                        timeout += self.idle_timeout;
+                    }
+                }
+            }
+        }
+    }
+}
+
+pub struct ThreadPool {
+    shared: Arc<Shared>,
+}
+
+impl ThreadPool {
+    pub fn new(config: &InstallConfig, metrics: &MetricRegistry) -> Self {
+        let pool = ThreadPool {
+            shared: Arc::new(Shared {
+                min_threads: config.server().min_threads(),
+                max_threads: config.server().max_threads(),
+                idle_timeout: config.server().idle_thread_timeout(),
+                queue: JobQueue::new(),
+                state: Mutex::new(State {
+                    threads: 0,
+                    idle_threads: 0,
+                    next_id: 0,
+                }),
+            }),
+        };
+
+        metrics.gauge("server.worker.max", {
+            let shared = pool.shared.clone();
+            move || shared.max()
+        });
+        metrics.gauge("server.worker.active", {
+            let shared = pool.shared.clone();
+            move || shared.active()
+        });
+        metrics.gauge("server.worker.utilization-max", {
+            let shared = pool.shared.clone();
+            move || shared.utilization_max()
+        });
+
+        let mut state = pool.shared.state.lock();
+        for _ in 0..config.server().min_threads() {
+            pool.add_thread(&mut state);
+        }
+        drop(state);
+
+        pool
+    }
+
+    fn add_thread(&self, state: &mut State) {
+        if state.threads >= self.shared.max_threads {
+            return;
+        }
+
+        let id = state.next_id;
+        state.next_id += 1;
+        let r = thread::Builder::new().name(format!("server-{id}")).spawn({
+            let shared = self.shared.clone();
+            move || shared.worker_loop()
+        });
+
+        if let Err(e) = r {
+            error!(
+                "failed to spawn new worker thread",
+                error: Error::internal_safe(e)
+            );
+        }
+    }
+
+    pub fn try_execute<F>(&self, f: F) -> Result<(), F>
+    where
+        F: FnOnce() + 'static + Send,
+    {
+        let mut state = self.shared.state.lock();
+        let current_jobs = self.shared.queue.len() + state.active();
+        if current_jobs >= self.shared.max_threads {
+            return Err(f);
+        }
+
+        self.shared.queue.push(Box::new(f));
+
+        if self.shared.queue.len() > state.idle_threads {
+            self.add_thread(&mut state);
+        }
+
+        Ok(())
+    }
+}

--- a/witchcraft-server/src/lib.rs
+++ b/witchcraft-server/src/lib.rs
@@ -74,6 +74,7 @@ use witchcraft_metrics::MetricRegistry;
 #[doc(inline)]
 pub use witchcraft_server_config as config;
 
+pub mod blocking;
 mod body;
 mod configs;
 mod endpoint;
@@ -173,22 +174,18 @@ where
         metrics,
         client_factory,
         handle: handle.clone(),
+        install_config: install_config.as_ref().clone(),
+        thread_pool: None,
         endpoints: vec![],
     };
 
-    let base_install_config = install_config.as_ref().clone();
-
     init(install_config, runtime_config, &mut witchcraft)?;
 
-    handle.block_on(server::start(
-        &base_install_config,
-        &mut witchcraft,
-        loggers.request_logger,
-    ))?;
+    handle.block_on(server::start(&mut witchcraft, loggers.request_logger))?;
 
     handle.block_on(shutdown(
         shutdown_hooks,
-        base_install_config.server().shutdown_timeout(),
+        witchcraft.install_config.server().shutdown_timeout(),
     ))
 }
 

--- a/witchcraft-server/src/server.rs
+++ b/witchcraft-server/src/server.rs
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-use crate::endpoint::extended_path::ExtendedPathEndpoint;
 use crate::logging::api::RequestLogV2;
 use crate::logging::Appender;
 use crate::service::accept::AcceptService;
@@ -49,26 +48,16 @@ use std::mem;
 use std::sync::Arc;
 use tokio::task;
 use witchcraft_log::debug;
-use witchcraft_server_config::install::InstallConfig;
 
 pub type RawBody = RequestLogRequestBody<SpannedBody<hyper::Body>>;
 
 pub async fn start(
-    config: &InstallConfig,
     witchcraft: &mut Witchcraft,
     request_logger: Appender<RequestLogV2>,
 ) -> Result<(), Error> {
-    let mut endpoints = mem::take(&mut witchcraft.endpoints);
-    if config.context_path() != "/" {
-        endpoints = endpoints
-            .into_iter()
-            .map(|e| Box::new(ExtendedPathEndpoint::new(e, config.context_path())) as _)
-            .collect();
-    }
-
     // This service handles individual HTTP requests, each running concurrently.
     let request_service = ServiceBuilder::new()
-        .layer(RoutingLayer::new(endpoints))
+        .layer(RoutingLayer::new(mem::take(&mut witchcraft.endpoints)))
         .layer(RequestIdLayer)
         .layer(TracePropagationLayer)
         .layer(SpansLayer)
@@ -76,10 +65,10 @@ pub async fn start(
         .layer(MdcLayer)
         .layer(WitchcraftMdcLayer)
         .layer(RequestLogLayer::new(request_logger))
-        .layer(GzipLayer::new(config))
+        .layer(GzipLayer::new(&witchcraft.install_config))
         .layer(DeprecationHeaderLayer)
-        .layer(KeepAliveHeaderLayer::new(config))
-        .layer(ServerHeaderLayer::new(config)?)
+        .layer(KeepAliveHeaderLayer::new(&witchcraft.install_config))
+        .layer(ServerHeaderLayer::new(&witchcraft.install_config)?)
         .layer(NoCachingLayer)
         .layer(WebSecurityLayer)
         .layer(TraceIdHeaderLayer)
@@ -91,18 +80,21 @@ pub async fn start(
 
     // This layer handles individual TCP connections, each running concurrently.
     let handle_service = ServiceBuilder::new()
-        .layer(TlsLayer::new(config)?)
+        .layer(TlsLayer::new(&witchcraft.install_config)?)
         .layer(TlsMetricsLayer::new(&witchcraft.metrics))
         .layer(ClientCertificateLayer)
-        .layer(IdleConnectionLayer::new(config))
+        .layer(IdleConnectionLayer::new(&witchcraft.install_config))
         .service(HyperService::new(request_service));
     let handle_service = Arc::new(handle_service);
 
     // This layer produces TCP connections, running serially.
     let accept_service = ServiceBuilder::new()
-        .layer(ConnectionLimitLayer::new(config))
-        .layer(ConnectionMetricsLayer::new(config, &witchcraft.metrics))
-        .service(AcceptService::new(config)?);
+        .layer(ConnectionLimitLayer::new(&witchcraft.install_config))
+        .layer(ConnectionMetricsLayer::new(
+            &witchcraft.install_config,
+            &witchcraft.metrics,
+        ))
+        .service(AcceptService::new(&witchcraft.install_config)?);
 
     task::spawn(async move {
         loop {


### PR DESCRIPTION
Most of the complex code (the thread pool, etc) is lifted directly from our internal implementation.