### PR TITLE
[25/n] Add the status endpoints

### DIFF
--- a/witchcraft-server/src/endpoint/errors.rs
+++ b/witchcraft-server/src/endpoint/errors.rs
@@ -27,8 +27,7 @@ where
 {
     let mut response = match error.kind() {
         ErrorKind::Service(service) => {
-            let body = conjure_error::encode(service);
-            let body = json::to_vec(&body).unwrap();
+            let body = json::to_vec(service).unwrap();
             let mut response = Response::new(body_creator(Some(Bytes::from(body))));
             *response.status_mut() =
                 StatusCode::from_u16(service.error_code().status_code()).unwrap();

--- a/witchcraft-server/src/health/mod.rs
+++ b/witchcraft-server/src/health/mod.rs
@@ -51,17 +51,20 @@ pub struct HealthCheckResult {
 
 impl HealthCheckResult {
     /// Health state of the check.
+    #[inline]
     pub fn state(&self) -> &HealthState {
         &self.state
     }
 
     /// Text describing the state of the check which should provide enough information for the check to be actionable
     /// when included in an alert.
+    #[inline]
     pub fn message(&self) -> Option<&str> {
         self.message.as_deref()
     }
 
     /// Additional redacted information on the nature of the health check.
+    #[inline]
     pub fn params(&self) -> &BTreeMap<String, Any> {
         &self.params
     }

--- a/witchcraft-server/src/health/registry.rs
+++ b/witchcraft-server/src/health/registry.rs
@@ -106,7 +106,6 @@ impl HealthCheckRegistry {
         }
     }
 
-    #[allow(dead_code)]
     pub(crate) fn run_checks(&self) -> HealthStatus {
         let threshold = Instant::now() - STALENESS_THRESHOLD;
         let mut stale_checks = vec![];

--- a/witchcraft-server/src/readiness.rs
+++ b/witchcraft-server/src/readiness.rs
@@ -1,0 +1,124 @@
+// Copyright 2022 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//! Readiness checks.
+use once_cell::sync::Lazy;
+use parking_lot::Mutex;
+use regex::Regex;
+use serde::Serialize;
+use staged_builder::staged_builder;
+use std::collections::btree_map;
+use std::collections::hash_map;
+use std::collections::{BTreeMap, HashMap};
+use std::sync::Arc;
+
+static TYPE_PATTERN: Lazy<Regex> = Lazy::new(|| Regex::new("^[A-Z_]+$").unwrap());
+
+/// A readiness check.
+pub trait ReadinessCheck {
+    /// Returns the check's type.
+    ///
+    /// The type must be `SCREAMING_SNAKE_CASE`.
+    fn type_(&self) -> &str;
+
+    /// Performs the check, returning its result.
+    fn result(&self) -> ReadinessCheckResult;
+}
+
+/// The result of a readiness check.
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[staged_builder]
+pub struct ReadinessCheckResult {
+    successful: bool,
+}
+
+impl ReadinessCheckResult {
+    /// The success of the check.
+    #[inline]
+    pub fn successful(&self) -> bool {
+        self.successful
+    }
+}
+
+/// A registry of readiness checks for the server.
+pub struct ReadinessCheckRegistry {
+    checks: Mutex<HashMap<String, Arc<dyn ReadinessCheck + Sync + Send>>>,
+}
+
+impl ReadinessCheckRegistry {
+    pub(crate) fn new() -> Self {
+        ReadinessCheckRegistry {
+            checks: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Registers a new readiness check.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the check's type is not `SCREAMING_SNAKE_CASE` or if a check with the same type is already registered.
+    pub fn register<T>(&self, check: T)
+    where
+        T: ReadinessCheck + 'static + Sync + Send,
+    {
+        self.register_inner(Arc::new(check))
+    }
+
+    fn register_inner(&self, check: Arc<dyn ReadinessCheck + Sync + Send>) {
+        let type_ = check.type_();
+
+        assert!(
+            TYPE_PATTERN.is_match(type_),
+            "{type_} must `SCREAMING_SNAKE_CASE",
+        );
+
+        match self.checks.lock().entry(type_.to_string()) {
+            hash_map::Entry::Occupied(_) => {
+                panic!("a check has already been registered for type {type_}")
+            }
+            hash_map::Entry::Vacant(e) => {
+                e.insert(check);
+            }
+        }
+    }
+
+    pub(crate) fn run_checks(&self) -> BTreeMap<String, ReadinessCheckMetadata> {
+        // A bit of extra complexity to allow registration while we're running checks.
+        let mut results = BTreeMap::new();
+
+        let mut progress = true;
+        while progress {
+            progress = false;
+            let checks = self.checks.lock().clone();
+
+            for (type_, check) in checks {
+                if let btree_map::Entry::Vacant(e) = results.entry(type_.clone()) {
+                    let result = check.result();
+                    e.insert(ReadinessCheckMetadata {
+                        r#type: type_,
+                        successful: result.successful,
+                    });
+                    progress = true;
+                }
+            }
+        }
+
+        results
+    }
+}
+
+#[derive(Serialize)]
+pub(crate) struct ReadinessCheckMetadata {
+    r#type: String,
+    pub(crate) successful: bool,
+}

--- a/witchcraft-server/src/status.rs
+++ b/witchcraft-server/src/status.rs
@@ -1,0 +1,260 @@
+// Copyright 2022 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+use crate::health::HealthCheckRegistry;
+use crate::readiness::ReadinessCheckRegistry;
+use crate::{RequestBody, ResponseWriter};
+use async_trait::async_trait;
+use bytes::Bytes;
+use conjure_error::{Error, PermissionDenied};
+use conjure_http::server::{
+    AsyncEndpoint, AsyncResponseBody, AsyncService, EndpointMetadata, PathSegment,
+};
+use conjure_http::SafeParams;
+use conjure_serde::json;
+use http::header::{AUTHORIZATION, CONTENT_TYPE};
+use http::{HeaderValue, Method, Request, Response, StatusCode};
+use openssl::memcmp;
+use refreshable::Refreshable;
+use std::borrow::Cow;
+use std::sync::Arc;
+use tokio::task;
+use witchcraft_server_config::runtime::RuntimeConfig;
+
+#[allow(clippy::declare_interior_mutable_const)]
+const APPLICATION_JSON: HeaderValue = HeaderValue::from_static("application/json");
+
+struct State {
+    health_check_auth: Refreshable<String, Error>,
+    health_checks: Arc<HealthCheckRegistry>,
+    readiness_checks: Arc<ReadinessCheckRegistry>,
+}
+
+// Manually implemented because readiness isn't fully definable in Conjure.
+pub struct StatusEndpoints {
+    state: Arc<State>,
+}
+
+impl StatusEndpoints {
+    pub fn new<R>(
+        runtime_config: &Refreshable<R, Error>,
+        health_checks: &Arc<HealthCheckRegistry>,
+        readiness_checks: &Arc<ReadinessCheckRegistry>,
+    ) -> Self
+    where
+        R: AsRef<RuntimeConfig> + PartialEq + 'static + Sync + Send,
+    {
+        StatusEndpoints {
+            state: Arc::new(State {
+                health_check_auth: runtime_config
+                    .map(|c| format!("Bearer {}", c.as_ref().health_checks().shared_secret())),
+                health_checks: health_checks.clone(),
+                readiness_checks: readiness_checks.clone(),
+            }),
+        }
+    }
+}
+
+impl AsyncService<RequestBody, ResponseWriter> for StatusEndpoints {
+    fn endpoints(&self) -> Vec<Box<dyn AsyncEndpoint<RequestBody, ResponseWriter> + Sync + Send>> {
+        vec![
+            Box::new(LivenessEndpoint),
+            Box::new(HealthEndpoint {
+                state: self.state.clone(),
+            }),
+            Box::new(ReadinessEndpoint {
+                state: self.state.clone(),
+            }),
+        ]
+    }
+}
+
+struct LivenessEndpoint;
+
+impl EndpointMetadata for LivenessEndpoint {
+    fn method(&self) -> Method {
+        Method::GET
+    }
+
+    fn path(&self) -> &[PathSegment] {
+        &[
+            PathSegment::Literal(Cow::Borrowed("status")),
+            PathSegment::Literal(Cow::Borrowed("liveness")),
+        ]
+    }
+
+    fn template(&self) -> &str {
+        "/status/liveness"
+    }
+
+    fn service_name(&self) -> &str {
+        "StatusService"
+    }
+
+    fn name(&self) -> &str {
+        "liveness"
+    }
+
+    fn deprecated(&self) -> Option<&str> {
+        None
+    }
+}
+
+#[async_trait]
+impl AsyncEndpoint<RequestBody, ResponseWriter> for LivenessEndpoint {
+    async fn handle(
+        &self,
+        _: &mut SafeParams,
+        _: Request<RequestBody>,
+    ) -> Result<Response<AsyncResponseBody<ResponseWriter>>, Error> {
+        let mut response = Response::new(AsyncResponseBody::Empty);
+        *response.status_mut() = StatusCode::NO_CONTENT;
+        Ok(response)
+    }
+}
+
+struct HealthEndpoint {
+    state: Arc<State>,
+}
+
+impl EndpointMetadata for HealthEndpoint {
+    fn method(&self) -> Method {
+        Method::GET
+    }
+
+    fn path(&self) -> &[PathSegment] {
+        &[
+            PathSegment::Literal(Cow::Borrowed("status")),
+            PathSegment::Literal(Cow::Borrowed("health")),
+        ]
+    }
+
+    fn template(&self) -> &str {
+        "/status/health"
+    }
+
+    fn service_name(&self) -> &str {
+        "StatusService"
+    }
+
+    fn name(&self) -> &str {
+        "health"
+    }
+
+    fn deprecated(&self) -> Option<&str> {
+        None
+    }
+}
+
+#[async_trait]
+impl AsyncEndpoint<RequestBody, ResponseWriter> for HealthEndpoint {
+    async fn handle(
+        &self,
+        _: &mut SafeParams,
+        req: Request<RequestBody>,
+    ) -> Result<Response<AsyncResponseBody<ResponseWriter>>, Error> {
+        let authorization = match req.headers().get(AUTHORIZATION) {
+            Some(authorization) => authorization,
+            None => {
+                return Err(Error::service_safe(
+                    "health check secret missing",
+                    PermissionDenied::new(),
+                ))
+            }
+        };
+
+        // Using OpenSSL's constant time equality check
+        if !memcmp::eq(
+            authorization.as_bytes(),
+            self.state.health_check_auth.get().as_bytes(),
+        ) {
+            return Err(Error::service_safe(
+                "invalid health check secret",
+                PermissionDenied::new(),
+            ));
+        }
+
+        let health_checks = self.state.health_checks.run_checks();
+        let health_checks = json::to_vec(&health_checks).unwrap();
+        let mut response = Response::new(AsyncResponseBody::Fixed(Bytes::from(health_checks)));
+        response
+            .headers_mut()
+            .insert(CONTENT_TYPE, APPLICATION_JSON);
+
+        Ok(response)
+    }
+}
+
+struct ReadinessEndpoint {
+    state: Arc<State>,
+}
+
+impl EndpointMetadata for ReadinessEndpoint {
+    fn method(&self) -> Method {
+        Method::GET
+    }
+
+    fn path(&self) -> &[PathSegment] {
+        &[
+            PathSegment::Literal(Cow::Borrowed("status")),
+            PathSegment::Literal(Cow::Borrowed("readiness")),
+        ]
+    }
+
+    fn template(&self) -> &str {
+        "/status/readiness"
+    }
+
+    fn service_name(&self) -> &str {
+        "StatusService"
+    }
+
+    fn name(&self) -> &str {
+        "readiness"
+    }
+
+    fn deprecated(&self) -> Option<&str> {
+        None
+    }
+}
+
+#[async_trait]
+impl AsyncEndpoint<RequestBody, ResponseWriter> for ReadinessEndpoint {
+    async fn handle(
+        &self,
+        _: &mut SafeParams,
+        _: Request<RequestBody>,
+    ) -> Result<Response<AsyncResponseBody<ResponseWriter>>, Error> {
+        let readiness_checks = task::spawn_blocking({
+            let readiness_checks = self.state.readiness_checks.clone();
+            move || readiness_checks.run_checks()
+        })
+        .await
+        .unwrap();
+
+        let status = if readiness_checks.values().all(|r| r.successful) {
+            StatusCode::OK
+        } else {
+            StatusCode::SERVICE_UNAVAILABLE
+        };
+
+        let readiness_checks = json::to_vec(&readiness_checks).unwrap();
+        let mut response = Response::new(AsyncResponseBody::Fixed(Bytes::from(readiness_checks)));
+        *response.status_mut() = status;
+        response
+            .headers_mut()
+            .insert(CONTENT_TYPE, APPLICATION_JSON);
+
+        Ok(response)
+    }
+}


### PR DESCRIPTION
We unfortunately can't Conjure-generate these since readiness needs to be able to return a 503 with a custom response body :(.

~~Compared to our internal implementation, this doesn't currently have the health status code special casing for the old deployd LTS version - I will need to check if that's still relevant.~~ All supported releases of our deployment infrastructure support the new health check endpoint behvaior.

Mirroring WC-Java, the `ReadinessCheckRegistry` is much simpler than the `HealthCheckRegistry`, since readiness checks should just be polling the state of initialization work happening elsewhere.