### PR TITLE
[28/n] Ensure initialization-time problems are logged

### DIFF
--- a/witchcraft-server/Cargo.toml
+++ b/witchcraft-server/Cargo.toml
@@ -75,7 +75,7 @@ tokio = { version = "1", features = [
     "time",
 ] }
 tokio-openssl = "0.6"
-tokio-util = "0.6"
+tokio-util = "0.7"
 witchcraft-log = "0.3"
 witchcraft-metrics = "0.2"
 zipkin = "0.4"

--- a/witchcraft-server/src/logging/mod.rs
+++ b/witchcraft-server/src/logging/mod.rs
@@ -41,6 +41,10 @@ pub struct Loggers {
     pub request_logger: Appender<RequestLogV2>,
 }
 
+pub fn early_init() {
+    service::early_init()
+}
+
 pub async fn init(
     metrics: &Arc<MetricRegistry>,
     install: &InstallConfig,


### PR DESCRIPTION
We previously only flushed the loggers as part of the graceful shutdown process. In particular, that meant we wouldn't shut down the logger if the user-provided initialization function failed or panicked and the logs from those errors would most likely be lost. In addition, we would have to double-log errors because we didn't know if the service logger was set up.

To fix these problems, we initialize the service logger very early, with it initially logging to standard out. It's then reconfigured as part of the standard log initialization step once we have our configuration. We also move the logger flush hooks to run when the Runtime drops, and move that out to after the top-level error reporting to ensure it always happens after all of the logs we care about.