### PR TITLE
[31/n] Support request and response trailers

### DIFF
--- a/witchcraft-server-ete/Cargo.toml
+++ b/witchcraft-server-ete/Cargo.toml
@@ -16,12 +16,14 @@ async-trait = "0.1"
 conjure-error = "0.7"
 conjure-http = "0.7"
 conjure-object = "0.7"
+http = "0.2"
 refreshable = "1"
 tokio = "1"
 
 witchcraft-server = { path = "../witchcraft-server" }
 
 [dev-dependencies]
+bytes = "1"
 conjure-serde = "0.7"
 hyper = "0.14"
 libc = "0.2"

--- a/witchcraft-server-ete/test-ir.json
+++ b/witchcraft-server-ete/test-ir.json
@@ -140,6 +140,29 @@
       },
       "markers" : [ ],
       "tags" : [ ]
+    }, {
+      "endpointName" : "trailers",
+      "httpMethod" : "POST",
+      "httpPath" : "/test/trailers",
+      "args" : [ {
+        "argName" : "body",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "BINARY"
+        },
+        "paramType" : {
+          "type" : "body",
+          "body" : { }
+        },
+        "markers" : [ ],
+        "tags" : [ ]
+      } ],
+      "returns" : {
+        "type" : "primitive",
+        "primitive" : "BINARY"
+      },
+      "markers" : [ ],
+      "tags" : [ ]
     } ]
   } ],
   "extensions" : { }

--- a/witchcraft-server-ete/test.yml
+++ b/witchcraft-server-ete/test.yml
@@ -45,3 +45,8 @@ services:
             type: integer
             param-type: query
         returns: binary
+      trailers:
+        http: POST /trailers
+        args:
+          body: binary
+        returns: binary

--- a/witchcraft-server-ete/tests/ete/main.rs
+++ b/witchcraft-server-ete/tests/ete/main.rs
@@ -11,11 +11,15 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+use bytes::Bytes;
 use conjure_object::Any;
+use http::{HeaderMap, HeaderValue};
 use hyper::body::HttpBody;
 use hyper::{body, Body, Request, StatusCode};
 use server::Server;
+use std::pin::Pin;
 use std::str;
+use std::task::{Context, Poll};
 use std::time::{Duration, Instant};
 use tokio::time;
 
@@ -23,18 +27,17 @@ mod server;
 
 #[tokio::test]
 async fn safe_params() {
-    Server::with(|mut server| async move {
-        let mut client = server.client().await.unwrap();
+    Server::with(|server| async move {
         let request = Request::builder()
             .uri("/witchcraft-ete/api/test/safeParams/expected%20safe%20path/expected%20unsafe%20path?safeQueryId=\
                   expected%20safe%20query&unsafeQueryId=expected%20unsafe%20query")
             .header("Safe-Header", "expected safe header")
             .header("Unsafe-Header", "expected unsafe header")
             .body(Body::empty()).unwrap();
-        let response = client.send_request(request).await.unwrap();
+        let response = server.client().await.unwrap().send_request(request).await.unwrap();
         assert_eq!(response.status(), StatusCode::NO_CONTENT);
 
-        let logs = server.shutdown();
+        let logs = server.shutdown().await;
         let request = logs.only_request();
 
         assert_eq!(
@@ -91,6 +94,9 @@ async fn keep_alive_slow_headers() {
             .body(Body::empty())
             .unwrap();
         client.send_request(request).await.err().unwrap();
+
+        drop(client);
+        server.shutdown().await;
     })
     .await;
 }
@@ -134,6 +140,9 @@ async fn keep_alive_slow_body() {
             .body(Body::empty())
             .unwrap();
         client.send_request(request).await.err().unwrap();
+
+        drop(client);
+        server.shutdown().await;
     })
     .await;
 }
@@ -141,13 +150,17 @@ async fn keep_alive_slow_body() {
 #[tokio::test]
 async fn graceful_shutdown() {
     Server::with(|mut server| async move {
-        let mut client = server.client().await.unwrap();
-
         let request = Request::builder()
             .uri("/witchcraft-ete/api/test/slowBody?delayMillis=1500")
             .body(Body::empty())
             .unwrap();
-        let response = client.send_request(request).await.unwrap();
+        let response = server
+            .client()
+            .await
+            .unwrap()
+            .send_request(request)
+            .await
+            .unwrap();
         assert_eq!(response.status(), StatusCode::OK);
 
         let mut body = response.into_body();
@@ -159,7 +172,7 @@ async fn graceful_shutdown() {
         body.data().await.unwrap().unwrap();
         assert_eq!(&chunk[..], &[0]);
 
-        let logs = server.finish_shutdown();
+        let logs = server.finish_shutdown().await;
         logs.only_request();
     })
     .await;
@@ -168,14 +181,18 @@ async fn graceful_shutdown() {
 #[tokio::test]
 async fn diagnostic_types_diagnostic() {
     Server::with(|server| async move {
-        let mut client = server.client().await.unwrap();
-
         let request = Request::builder()
             .uri("/witchcraft-ete/debug/diagnostic/diagnostic.types.v1")
             .header("Authorization", "Bearer debug")
             .body(Body::empty())
             .unwrap();
-        let response = client.send_request(request).await.unwrap();
+        let response = server
+            .client()
+            .await
+            .unwrap()
+            .send_request(request)
+            .await
+            .unwrap();
 
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(response.headers().get("Safe-Loggable").unwrap(), "true");
@@ -187,6 +204,76 @@ async fn diagnostic_types_diagnostic() {
         let body = body::to_bytes(response.into_body()).await.unwrap();
         let body = str::from_utf8(&body).unwrap();
         assert!(body.contains("\"diagnostic.types.v1\""));
+
+        server.shutdown().await;
     })
     .await;
+}
+
+#[tokio::test]
+async fn trailers() {
+    Server::builder()
+        .http2(true)
+        .with(|server| async move {
+            let request = Request::builder()
+                .method("POST")
+                .uri("/witchcraft-ete/api/test/trailers")
+                .header("Content-Type", "application/octet-stream")
+                .body(TrailersBody { sent_body: false })
+                .unwrap();
+            let mut response = server
+                .client()
+                .await
+                .unwrap()
+                .send_request(request)
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+
+            let bytes = body::to_bytes(&mut response).await.unwrap();
+            assert_eq!(bytes, "expected response body");
+
+            let trailers = response.trailers().await.unwrap().unwrap();
+            assert_eq!(
+                trailers.get("Response-Trailer").unwrap(),
+                "expected response trailer value",
+            );
+
+            server.shutdown().await;
+        })
+        .await;
+}
+
+struct TrailersBody {
+    sent_body: bool,
+}
+
+impl HttpBody for TrailersBody {
+    type Data = Bytes;
+
+    type Error = String;
+
+    fn poll_data(
+        mut self: Pin<&mut Self>,
+        _: &mut Context<'_>,
+    ) -> Poll<Option<Result<Self::Data, Self::Error>>> {
+        if self.sent_body {
+            Poll::Ready(None)
+        } else {
+            self.sent_body = true;
+            Poll::Ready(Some(Ok(Bytes::from("expected request body"))))
+        }
+    }
+
+    fn poll_trailers(
+        self: Pin<&mut Self>,
+        _: &mut Context<'_>,
+    ) -> Poll<Result<Option<http::HeaderMap>, Self::Error>> {
+        let mut trailers = HeaderMap::new();
+        trailers.insert(
+            "Request-Trailer",
+            HeaderValue::from_static("expected request trailer value"),
+        );
+        Poll::Ready(Ok(Some(trailers)))
+    }
 }

--- a/witchcraft-server-ete/tests/ete/server/install.yml
+++ b/witchcraft-server-ete/tests/ete/server/install.yml
@@ -4,6 +4,7 @@ port: <PORT>
 use-console-log: true
 context-path: /witchcraft-ete
 server:
+  http2: <HTTP2>
   io-threads: 1
   min-threads: 1
   idle-connection-timeout: 2s

--- a/witchcraft-server-ete/tests/ete/server/mod.rs
+++ b/witchcraft-server-ete/tests/ete/server/mod.rs
@@ -1,20 +1,22 @@
 use api::{LogLevel, RequestLogV2, ServiceLogV1};
 use conjure_serde::json;
+use hyper::body::HttpBody;
 use hyper::client::conn::{self, SendRequest};
-use hyper::{Body, Request};
+use hyper::Request;
 use openssl::ssl::{SslConnector, SslMethod};
-use std::error::Error;
+use std::error::{self, Error};
+use std::fs::File;
 use std::future::Future;
-use std::io::Read;
+use std::io::{Read, Write};
 use std::net::TcpListener;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::process::{Child, Command, Stdio};
-use std::sync::mpsc;
 use std::time::Duration;
 use std::{env, fs, thread};
 use tempfile::TempDir;
 use tokio::net::TcpStream;
+use tokio::sync::oneshot;
 use tokio::{task, time};
 use tokio_openssl::SslStream;
 
@@ -42,7 +44,7 @@ fn open_port() -> u16 {
     listener.local_addr().unwrap().port()
 }
 
-fn setup_config(dir: &Path, port: u16) {
+fn setup_config(dir: &Path, builder: &Builder, port: u16) {
     let conf = dir.join("var/conf");
     fs::create_dir_all(&conf).unwrap();
     fs::write(
@@ -52,7 +54,9 @@ fn setup_config(dir: &Path, port: u16) {
     .unwrap();
     fs::write(
         conf.join("install.yml"),
-        include_str!("install.yml").replace("<PORT>", &port.to_string()),
+        include_str!("install.yml")
+            .replace("<PORT>", &port.to_string())
+            .replace("<HTTP2>", &builder.http2.to_string()),
     )
     .unwrap();
     fs::write(conf.join("runtime.yml"), include_str!("runtime.yml")).unwrap();
@@ -66,45 +70,45 @@ fn setup_config(dir: &Path, port: u16) {
 pub struct Server {
     dir: PathBuf,
     child: Child,
-    stdout_rx: mpsc::Receiver<String>,
+    stdout_rx: Option<oneshot::Receiver<String>>,
     ctx: SslConnector,
     port: u16,
     shutdown: bool,
+    http2: bool,
 }
 
 impl Drop for Server {
     fn drop(&mut self) {
-        println!("server dir: {}", self.dir.display());
         if thread::panicking() {
+            println!("server dir: {}", self.dir.display());
             if !self.shutdown {
                 let _ = self.child.kill();
             }
         } else {
-            if !self.shutdown {
-                self.shutdown();
-            }
+            assert!(self.shutdown, "test did not shut down the server");
             let _ = fs::remove_dir_all(&self.dir);
         }
     }
 }
 
 impl Server {
+    pub fn builder() -> Builder {
+        Builder { http2: false }
+    }
+
     pub async fn with<F, G>(test: F)
     where
         F: Fn(Server) -> G,
         G: Future<Output = ()>,
     {
-        for handler_type in ["blocking", "async"] {
-            let server = Server::new(handler_type).await;
-            test(server).await;
-        }
+        Self::builder().with(test).await
     }
 
-    async fn new(handler_type: &str) -> Self {
+    async fn new(builder: &Builder, handler_type: &str) -> Self {
         let dir = TempDir::new().unwrap();
         let port = open_port();
 
-        setup_config(dir.path(), port);
+        setup_config(dir.path(), builder, port);
 
         let binary = env::current_exe()
             .unwrap()
@@ -120,7 +124,7 @@ impl Server {
             .unwrap();
 
         let mut stdout = child.stdout.take().unwrap();
-        let (tx, stdout_rx) = mpsc::channel();
+        let (tx, stdout_rx) = oneshot::channel();
         thread::spawn(move || {
             let mut buf = String::new();
             stdout.read_to_string(&mut buf).unwrap();
@@ -130,15 +134,24 @@ impl Server {
         let mut ctx = SslConnector::builder(SslMethod::tls()).unwrap();
         ctx.set_ca_file(dir.path().join("var/security/cert.cer"))
             .unwrap();
+        if builder.http2 {
+            ctx.set_alpn_protos(b"\x02h2").unwrap();
+        }
+        let file = File::create(dir.path().join("keylog")).unwrap();
+        ctx.set_keylog_callback(move |_, b| {
+            let _ = (&file).write_all(b.as_bytes());
+            let _ = (&file).write_all(b"\n");
+        });
         let ctx = ctx.build();
 
         let server = Server {
             dir: dir.into_path(),
             child,
-            stdout_rx,
+            stdout_rx: Some(stdout_rx),
             ctx,
             port,
             shutdown: false,
+            http2: builder.http2,
         };
 
         server.wait_for_ready().await;
@@ -158,7 +171,7 @@ impl Server {
 
             let request = Request::builder()
                 .uri("/witchcraft-ete/status/readiness")
-                .body(Body::empty())
+                .body(hyper::Body::empty())
                 .unwrap();
 
             match client.send_request(request).await {
@@ -167,18 +180,24 @@ impl Server {
             }
         }
 
-        panic!(
-            "timed out waiting for the server to report readiness:\n{}",
-            self.stdout_rx.try_iter().collect::<Vec<_>>().join("\n"),
-        );
+        panic!("timed out waiting for the server to report readiness");
     }
 
-    pub async fn client(&self) -> Result<SendRequest<Body>, Box<dyn Error + Sync + Send>> {
+    pub async fn client<B>(&self) -> Result<SendRequest<B>, Box<dyn Error + Sync + Send>>
+    where
+        B: HttpBody + 'static + Send,
+        B::Data: Send,
+        B::Error: Into<Box<dyn error::Error + Sync + Send>>,
+    {
         let stream = TcpStream::connect(("127.0.0.1", self.port)).await?;
         let ssl = self.ctx.configure()?.into_ssl("localhost")?;
         let mut stream = SslStream::new(ssl, stream)?;
         Pin::new(&mut stream).connect().await?;
-        let (client, connection) = conn::handshake(stream).await?;
+        let (client, connection) = conn::Builder::new()
+            .http2_only(self.http2)
+            .handshake(stream)
+            .await
+            .unwrap();
 
         task::spawn(async {
             let _ = connection.await;
@@ -187,25 +206,26 @@ impl Server {
         Ok(client)
     }
 
-    pub fn shutdown(&mut self) -> ServerLogs {
+    pub async fn shutdown(mut self) -> ServerLogs {
         self.start_shutdown();
-        self.finish_shutdown()
+        self.finish_shutdown().await
     }
 
     pub fn start_shutdown(&mut self) {
-        self.shutdown = true;
         unsafe {
             libc::kill(self.child.id() as libc::pid_t, libc::SIGINT);
         }
     }
 
-    pub fn finish_shutdown(&mut self) -> ServerLogs {
+    pub async fn finish_shutdown(mut self) -> ServerLogs {
+        self.shutdown = true;
+
         let mut logs = ServerLogs {
             service: vec![],
             request: vec![],
         };
 
-        let stdout = self.stdout_rx.recv().unwrap();
+        let stdout = self.stdout_rx.take().unwrap().await.unwrap();
         for line in stdout.lines() {
             if line.contains("service.1") {
                 logs.service.push(json::server_from_str(line).unwrap());
@@ -216,6 +236,28 @@ impl Server {
 
         logs.assert_no_errors();
         logs
+    }
+}
+
+pub struct Builder {
+    http2: bool,
+}
+
+impl Builder {
+    pub fn http2(mut self, http2: bool) -> Self {
+        self.http2 = http2;
+        self
+    }
+
+    pub async fn with<F, G>(self, test: F)
+    where
+        F: Fn(Server) -> G,
+        G: Future<Output = ()>,
+    {
+        for handler_type in ["blocking", "async"] {
+            let server = Server::new(&self, handler_type).await;
+            test(server).await;
+        }
     }
 }
 

--- a/witchcraft-server/Cargo.toml
+++ b/witchcraft-server/Cargo.toml
@@ -76,6 +76,7 @@ tokio = { version = "1", features = [
 ] }
 tokio-openssl = "0.6"
 tokio-util = { version = "0.7", features = ["codec"] }
+tracing = { version = "0.1", features = ["log"] }
 witchcraft-log = "0.3"
 witchcraft-metrics = "0.2"
 zipkin = "0.4"


### PR DESCRIPTION
Since Conjure-generated services don't interact with trailers, this is primarily designed to allow integration with gRPC services. Due to how the conjure-http APIs work, the empty and fixed size response types can't have trailers set, but that shouldn't be that much of a problem in practice.

The ETE test for this feature exposed a problem with the design of the ETE harness setup: we previously blocked in Server's drop implemnetation waiting for the server to gracefully shutdown, but since `#[tokio::test]` uses a single threaded reactor that would prevent the HTTP2 connection from cleanly closing. To fix that, tests are now required to explicitly shut down the server when they're done running. They should also ensure that any clients have already been closed to avoid making the test wait for the idle connection timeout to elapse on shutdown.