### PR TITLE
[33/n] Improve handling of cancelled requests

### DIFF
--- a/witchcraft-server/src/blocking/cancellation.rs
+++ b/witchcraft-server/src/blocking/cancellation.rs
@@ -1,0 +1,54 @@
+// Copyright 2022 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+/// A type tracking the cancellation state of a request.
+///
+/// This type will be added to the extensions of each request made to a blocking endpoint.
+#[derive(Clone, Debug)]
+pub struct Cancellation {
+    cancelled: Arc<AtomicBool>,
+}
+
+impl Cancellation {
+    pub(crate) fn new() -> (Cancellation, CancellationGuard) {
+        let cancelled = Arc::new(AtomicBool::new(false));
+        (
+            Cancellation {
+                cancelled: cancelled.clone(),
+            },
+            CancellationGuard { cancelled },
+        )
+    }
+
+    /// Returns `true` if the client of a request has cancelled it.
+    ///
+    /// Long running blocking endpoint handlers should periodically check this to determine if they should continue
+    /// working or not.
+    #[inline]
+    pub fn is_cancelled(&self) -> bool {
+        self.cancelled.load(Ordering::Relaxed)
+    }
+}
+
+pub struct CancellationGuard {
+    cancelled: Arc<AtomicBool>,
+}
+
+impl Drop for CancellationGuard {
+    fn drop(&mut self) {
+        self.cancelled.store(true, Ordering::Relaxed);
+    }
+}

--- a/witchcraft-server/src/blocking/mod.rs
+++ b/witchcraft-server/src/blocking/mod.rs
@@ -13,7 +13,9 @@
 // limitations under the License.
 //! Blocking handler APIs.
 pub use body::{RequestBody, ResponseWriter};
+pub use cancellation::Cancellation;
 
 mod body;
+mod cancellation;
 pub(crate) mod conjure;
 pub(crate) mod pool;

--- a/witchcraft-server/src/server.rs
+++ b/witchcraft-server/src/server.rs
@@ -14,6 +14,7 @@
 use crate::logging::api::RequestLogV2;
 use crate::logging::Appender;
 use crate::service::accept::AcceptService;
+use crate::service::cancellation::CancellationLayer;
 use crate::service::catch_unwind::CatchUnwindLayer;
 use crate::service::client_certificate::ClientCertificateLayer;
 use crate::service::connection_limit::ConnectionLimitLayer;
@@ -69,6 +70,7 @@ pub async fn start(
         .layer(MdcLayer)
         .layer(WitchcraftMdcLayer)
         .layer(RequestLogLayer::new(request_logger))
+        .layer(CancellationLayer)
         .layer(GzipLayer::new(&witchcraft.install_config))
         .layer(DeprecationHeaderLayer)
         .layer(KeepAliveHeaderLayer::new(&witchcraft.install_config))

--- a/witchcraft-server/src/service/cancellation.rs
+++ b/witchcraft-server/src/service/cancellation.rs
@@ -1,0 +1,83 @@
+// Copyright 2022 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+use crate::service::{Layer, Service};
+use pin_project::{pin_project, pinned_drop};
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use witchcraft_log::info;
+
+/// A layer which logs a message when the inner service's future is dropped before completion.
+pub struct CancellationLayer;
+
+impl<S> Layer<S> for CancellationLayer {
+    type Service = CancellationService<S>;
+
+    fn layer(self, inner: S) -> Self::Service {
+        CancellationService { inner }
+    }
+}
+
+pub struct CancellationService<S> {
+    inner: S,
+}
+
+impl<S, R> Service<R> for CancellationService<S>
+where
+    S: Service<R>,
+{
+    type Response = S::Response;
+
+    type Future = CancellationFuture<S::Future>;
+
+    fn call(&self, req: R) -> Self::Future {
+        CancellationFuture {
+            inner: self.inner.call(req),
+            complete: false,
+        }
+    }
+}
+
+#[pin_project(PinnedDrop)]
+pub struct CancellationFuture<F> {
+    #[pin]
+    inner: F,
+    complete: bool,
+}
+
+#[pinned_drop]
+impl<F> PinnedDrop for CancellationFuture<F> {
+    fn drop(self: Pin<&mut Self>) {
+        let this = self.project();
+        if !*this.complete {
+            info!("request cancelled during processing");
+        }
+    }
+}
+
+impl<F> Future for CancellationFuture<F>
+where
+    F: Future,
+{
+    type Output = F::Output;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        let r = this.inner.poll(cx);
+        if r.is_ready() {
+            *this.complete = true;
+        }
+        r
+    }
+}

--- a/witchcraft-server/src/service/mod.rs
+++ b/witchcraft-server/src/service/mod.rs
@@ -15,6 +15,7 @@ use std::future::Future;
 use std::sync::Arc;
 
 pub mod accept;
+pub mod cancellation;
 pub mod catch_unwind;
 pub mod client_certificate;
 pub mod connection_limit;


### PR DESCRIPTION
If a client cancels a request, its associated future will be dropped. For nonblocking request handlers this can produce a confusing result where the task doing some work suddenly "vanishes". For blocking requests, the worker on the thread pool just keeps on running even though nothing is waiting on it anymore.

This PR adds a layer which logs a message when a request is cancelled (and updates the MDC layer slightly to ensure the logging state is set up properly). It also adds a `Cancellation` type that is added to the request extensions of blocking endpoints and can be queried to determine if the request has been cancelled or not. While extensions are not directly exposed to generated Conjure handlers, implementations that care about cancellation can use a handler wrapper to e.g. stick the value in a thread local for later retrieval.