### PR TITLE
Include the query in the unsafe path param of request logs

### DIFF
--- a/changelog/@unreleased/pr-43.v2.yml
+++ b/changelog/@unreleased/pr-43.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: The unsafe `path` parameter in request logs now contains the URI query
+    in addition to the path.
+  links:
+  - https://github.com/palantir/witchcraft-rust-server/pull/43

--- a/witchcraft-server-config/Cargo.toml
+++ b/witchcraft-server-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "witchcraft-server-config"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Configuration types for witchcraft-server"

--- a/witchcraft-server-macros/Cargo.toml
+++ b/witchcraft-server-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "witchcraft-server-macros"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Macro definitions used by witchcraft-server"

--- a/witchcraft-server/Cargo.toml
+++ b/witchcraft-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "witchcraft-server"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "A highly opinionated embedded application server for RESTy APIs, compatible with the Witchcraft ecosystem"
@@ -85,8 +85,8 @@ witchcraft-log = "1"
 witchcraft-metrics = "1"
 zipkin = "0.4"
 
-witchcraft-server-config = { version = "1.0.0", path = "../witchcraft-server-config" }
-witchcraft-server-macros = { version = "1.0.0", path = "../witchcraft-server-macros" }
+witchcraft-server-config = { version = "1.1.0", path = "../witchcraft-server-config" }
+witchcraft-server-macros = { version = "1.1.0", path = "../witchcraft-server-macros" }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 procinfo = "0.4"

--- a/witchcraft-server/src/service/request_log.rs
+++ b/witchcraft-server/src/service/request_log.rs
@@ -176,7 +176,13 @@ where
             }
         }
 
-        let unsafe_params = vec![("path".to_string(), Any::new(req.uri().path()).unwrap())];
+        let mut unsafe_params = vec![];
+        if let Some(path_and_query) = req.uri().path_and_query() {
+            unsafe_params.push((
+                "path".to_string(),
+                Any::new(path_and_query.as_str()).unwrap(),
+            ));
+        }
 
         let request_size = Arc::new(AtomicI64::new(0));
 


### PR DESCRIPTION
## Before this PR
The unsafe `path` parameter in request logs only contained the path component of the request URI.

## After this PR
==COMMIT_MSG==
The unsafe `path` parameter in request logs now contains the URI query in addition to the path.
==COMMIT_MSG==

