### PR TITLE
Fix ClientIo serialization

### DIFF
--- a/changelog/@unreleased/pr-48.v2.yml
+++ b/changelog/@unreleased/pr-48.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fixed a panic when a client-side IO error is encountered.
+  links:
+  - https://github.com/palantir/witchcraft-rust-server/pull/48

--- a/witchcraft-server-config/Cargo.toml
+++ b/witchcraft-server-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "witchcraft-server-config"
-version = "1.1.0"
+version = "1.2.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Configuration types for witchcraft-server"

--- a/witchcraft-server-macros/Cargo.toml
+++ b/witchcraft-server-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "witchcraft-server-macros"
-version = "1.1.0"
+version = "1.2.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Macro definitions used by witchcraft-server"

--- a/witchcraft-server/Cargo.toml
+++ b/witchcraft-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "witchcraft-server"
-version = "1.1.0"
+version = "1.2.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "A highly opinionated embedded application server for RESTy APIs, compatible with the Witchcraft ecosystem"
@@ -85,8 +85,8 @@ witchcraft-log = "1"
 witchcraft-metrics = "1"
 zipkin = "0.4"
 
-witchcraft-server-config = { version = "1.1.0", path = "../witchcraft-server-config" }
-witchcraft-server-macros = { version = "1.1.0", path = "../witchcraft-server-macros" }
+witchcraft-server-config = { version = "1.2.0", path = "../witchcraft-server-config" }
+witchcraft-server-macros = { version = "1.2.0", path = "../witchcraft-server-macros" }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 procinfo = "0.4"

--- a/witchcraft-server/src/body.rs
+++ b/witchcraft-server/src/body.rs
@@ -21,7 +21,7 @@ use futures_util::{future, ready, SinkExt, Stream};
 use http::HeaderMap;
 use http_body::Body;
 use pin_project::pin_project;
-use serde::ser::SerializeMap;
+use serde::ser::SerializeStruct;
 use serde::{Serialize, Serializer};
 use std::marker::PhantomPinned;
 use std::pin::Pin;
@@ -284,7 +284,7 @@ impl Serialize for ClientIo {
     where
         S: Serializer,
     {
-        serializer.serialize_map(Some(0))?.end()
+        serializer.serialize_struct("ClientIo", 0)?.end()
     }
 }
 
@@ -303,5 +303,15 @@ impl ErrorType for ClientIo {
 
     fn safe_args(&self) -> &'static [&'static str] {
         &[]
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn conjure_error_from_client_io() {
+        Error::service_safe("", ClientIo);
     }
 }


### PR DESCRIPTION
## Before this PR
A program would panic if a `conjure_error::Error` was ever created with a `ClientIo` error type.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Fixed a panic when a client-side IO error is encountered.
==COMMIT_MSG==

Closes #47 

