### PR TITLE
Fix a panic in auth token checks

### DIFF
--- a/changelog/@unreleased/pr-51.v2.yml
+++ b/changelog/@unreleased/pr-51.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Fixed a panic when querying the health check and diagnostic endpoints
+    with an invalid-length authorization token.
+  links:
+  - https://github.com/palantir/witchcraft-rust-server/pull/51

--- a/witchcraft-server-config/Cargo.toml
+++ b/witchcraft-server-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "witchcraft-server-config"
-version = "1.2.0"
+version = "1.3.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Configuration types for witchcraft-server"

--- a/witchcraft-server-macros/Cargo.toml
+++ b/witchcraft-server-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "witchcraft-server-macros"
-version = "1.2.0"
+version = "1.3.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Macro definitions used by witchcraft-server"

--- a/witchcraft-server/Cargo.toml
+++ b/witchcraft-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "witchcraft-server"
-version = "1.2.0"
+version = "1.3.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "A highly opinionated embedded application server for RESTy APIs, compatible with the Witchcraft ecosystem"
@@ -85,8 +85,8 @@ witchcraft-log = "1"
 witchcraft-metrics = "1"
 zipkin = "0.4"
 
-witchcraft-server-config = { version = "1.2.0", path = "../witchcraft-server-config" }
-witchcraft-server-macros = { version = "1.2.0", path = "../witchcraft-server-macros" }
+witchcraft-server-config = { version = "1.3.0", path = "../witchcraft-server-config" }
+witchcraft-server-macros = { version = "1.3.0", path = "../witchcraft-server-macros" }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 procinfo = "0.4"

--- a/witchcraft-server/Cargo.toml
+++ b/witchcraft-server/Cargo.toml
@@ -65,8 +65,8 @@ sequence_trie = "0.3"
 socket2 = "0.4"
 staged-builder = "0.1.1"
 sync_wrapper = "0.1"
-tikv-jemalloc-ctl = { version = "0.4", features = ["use_std"], optional = true }
-tikv-jemallocator = { version = "0.4", features = [
+tikv-jemalloc-ctl = { version = "0.5", features = ["use_std"], optional = true }
+tikv-jemallocator = { version = "0.5", features = [
     "unprefixed_malloc_on_supported_platforms",
     "background_threads",
     "profiling",

--- a/witchcraft-server/src/debug/endpoint.rs
+++ b/witchcraft-server/src/debug/endpoint.rs
@@ -127,8 +127,11 @@ impl AsyncEndpoint<RequestBody, ResponseWriter> for DiagnosticEndpoint {
             }
         };
 
-        // Using OpenSSL's constant time equality check
-        if !memcmp::eq(authorization.as_bytes(), self.state.auth.get().as_bytes()) {
+        let expected = self.state.auth.get();
+        // Using OpenSSL's constant time equality check, which requires the buffer lengths match
+        if authorization.len() != expected.len()
+            || !memcmp::eq(authorization.as_bytes(), expected.as_bytes())
+        {
             return Err(Error::service_safe(
                 "invalid diagnostic check secret",
                 PermissionDenied::new(),

--- a/witchcraft-server/src/status.rs
+++ b/witchcraft-server/src/status.rs
@@ -173,11 +173,11 @@ impl AsyncEndpoint<RequestBody, ResponseWriter> for HealthEndpoint {
             }
         };
 
-        // Using OpenSSL's constant time equality check
-        if !memcmp::eq(
-            authorization.as_bytes(),
-            self.state.health_check_auth.get().as_bytes(),
-        ) {
+        let expected = self.state.health_check_auth.get();
+        // Using OpenSSL's constant time equality check, which requires the buffer lengths match
+        if authorization.len() != expected.len()
+            || !memcmp::eq(authorization.as_bytes(), expected.as_bytes())
+        {
             return Err(Error::service_safe(
                 "invalid health check secret",
                 PermissionDenied::new(),


### PR DESCRIPTION
We use OpenSSL's constant time memcmp implementation, which requires that the two buffers have the same length. Previously if this wasn't the case, we'd panic.