### PR TITLE
Provide the mode when creating the crash log

### DIFF
--- a/changelog/@unreleased/pr-52.v2.yml
+++ b/changelog/@unreleased/pr-52.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fixed the permissions of the crash log file.
+  links:
+  - https://github.com/palantir/witchcraft-rust-server/pull/52

--- a/witchcraft-server-config/Cargo.toml
+++ b/witchcraft-server-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "witchcraft-server-config"
-version = "1.3.0"
+version = "1.4.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Configuration types for witchcraft-server"

--- a/witchcraft-server-macros/Cargo.toml
+++ b/witchcraft-server-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "witchcraft-server-macros"
-version = "1.3.0"
+version = "1.4.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Macro definitions used by witchcraft-server"

--- a/witchcraft-server/Cargo.toml
+++ b/witchcraft-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "witchcraft-server"
-version = "1.3.0"
+version = "1.4.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "A highly opinionated embedded application server for RESTy APIs, compatible with the Witchcraft ecosystem"
@@ -85,8 +85,8 @@ witchcraft-log = "1"
 witchcraft-metrics = "1"
 zipkin = "0.4"
 
-witchcraft-server-config = { version = "1.3.0", path = "../witchcraft-server-config" }
-witchcraft-server-macros = { version = "1.3.0", path = "../witchcraft-server-macros" }
+witchcraft-server-config = { version = "1.4.0", path = "../witchcraft-server-config" }
+witchcraft-server-macros = { version = "1.4.0", path = "../witchcraft-server-macros" }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 procinfo = "0.4"

--- a/witchcraft-server/src/crash.rs
+++ b/witchcraft-server/src/crash.rs
@@ -114,6 +114,7 @@ unsafe fn handler_inner(
     let ret = open(
         "var/log/crash.log\0".as_bytes().as_ptr().cast(),
         O_WRONLY | O_CREAT | O_TRUNC,
+        0o644,
     );
     if ret < 0 {
         return Err(());


### PR DESCRIPTION
Previously, the permissions of the crash log would be based off of random data from the stack!