### PR TITLE
Add the peer's socket address to request extensions

### DIFF
--- a/witchcraft-server/src/server.rs
+++ b/witchcraft-server/src/server.rs
@@ -31,6 +31,7 @@ use crate::service::idle_connection::IdleConnectionLayer;
 use crate::service::keep_alive_header::KeepAliveHeaderLayer;
 use crate::service::mdc::MdcLayer;
 use crate::service::no_caching::NoCachingLayer;
+use crate::service::peer_addr::PeerAddrLayer;
 use crate::service::request_id::RequestIdLayer;
 use crate::service::request_log::{RequestLogLayer, RequestLogRequestBody};
 use crate::service::routing::RoutingLayer;
@@ -87,6 +88,7 @@ pub async fn start(
 
     // This layer handles individual TCP connections, each running concurrently.
     let handle_service = ServiceBuilder::new()
+        .layer(PeerAddrLayer)
         .layer(TlsLayer::new(&witchcraft.install_config)?)
         .layer(TlsMetricsLayer::new(&witchcraft.metrics))
         .layer(ClientCertificateLayer)

--- a/witchcraft-server/src/service/accept.rs
+++ b/witchcraft-server/src/service/accept.rs
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+use crate::service::peer_addr::GetPeerAddr;
 use crate::service::Service;
 use conjure_error::Error;
 use futures_util::ready;
@@ -131,4 +132,10 @@ fn setup_socket(stream: &TcpStream) -> io::Result<()> {
     stream.set_nodelay(true)?;
     SockRef::from(stream).set_tcp_keepalive(&TcpKeepalive::new().with_time(TCP_KEEPALIVE))?;
     Ok(())
+}
+
+impl GetPeerAddr for TcpStream {
+    fn peer_addr(&self) -> Result<SocketAddr, Error> {
+        self.peer_addr().map_err(Error::internal_safe)
+    }
 }

--- a/witchcraft-server/src/service/connection_limit.rs
+++ b/witchcraft-server/src/service/connection_limit.rs
@@ -11,11 +11,14 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+use crate::service::peer_addr::GetPeerAddr;
 use crate::service::{Layer, Service};
+use conjure_error::Error;
 use futures_util::ready;
 use pin_project::pin_project;
 use std::future::Future;
 use std::io;
+use std::net::SocketAddr;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
@@ -169,5 +172,14 @@ where
 
     fn is_write_vectored(&self) -> bool {
         self.inner.is_write_vectored()
+    }
+}
+
+impl<S> GetPeerAddr for ConnectionLimitStream<S>
+where
+    S: GetPeerAddr,
+{
+    fn peer_addr(&self) -> Result<SocketAddr, Error> {
+        self.inner.peer_addr()
     }
 }

--- a/witchcraft-server/src/service/connection_metrics.rs
+++ b/witchcraft-server/src/service/connection_metrics.rs
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+use crate::service::peer_addr::GetPeerAddr;
 use crate::service::{Layer, Service};
 use futures_util::ready;
 use pin_project::{pin_project, pinned_drop};
@@ -157,5 +158,14 @@ where
 
     fn is_write_vectored(&self) -> bool {
         self.inner.is_write_vectored()
+    }
+}
+
+impl<S> GetPeerAddr for ConnectionMetricsStream<S>
+where
+    S: GetPeerAddr,
+{
+    fn peer_addr(&self) -> Result<std::net::SocketAddr, conjure_error::Error> {
+        self.inner.peer_addr()
     }
 }

--- a/witchcraft-server/src/service/mod.rs
+++ b/witchcraft-server/src/service/mod.rs
@@ -32,6 +32,7 @@ pub mod idle_connection;
 pub mod keep_alive_header;
 pub mod mdc;
 pub mod no_caching;
+pub mod peer_addr;
 pub mod request_id;
 pub mod request_log;
 pub mod routing;

--- a/witchcraft-server/src/service/peer_addr.rs
+++ b/witchcraft-server/src/service/peer_addr.rs
@@ -1,0 +1,99 @@
+// Copyright 2022 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::service::hyper::NewConnection;
+use crate::service::{Layer, Service, Stack};
+use conjure_error::Error;
+use futures_util::future::{self, Either};
+use http::Request;
+use std::net::SocketAddr;
+
+#[derive(Copy, Clone)]
+pub struct PeerAddr(pub SocketAddr);
+
+pub trait GetPeerAddr {
+    fn peer_addr(&self) -> Result<SocketAddr, Error>;
+}
+
+/// A layer which injects the peer's socket address into all requests made over the connection.
+pub struct PeerAddrLayer;
+
+impl<S> Layer<S> for PeerAddrLayer {
+    type Service = PeerAddrService<S>;
+
+    fn layer(self, inner: S) -> Self::Service {
+        PeerAddrService { inner }
+    }
+}
+
+pub struct PeerAddrService<S> {
+    inner: S,
+}
+
+impl<S, T, L, R> Service<NewConnection<T, L>> for PeerAddrService<S>
+where
+    S: Service<NewConnection<T, Stack<L, PeerAddrRequestLayer>>, Response = Result<R, Error>>,
+    T: GetPeerAddr,
+{
+    type Response = S::Response;
+
+    type Future = Either<S::Future, future::Ready<Result<R, Error>>>;
+
+    fn call(&self, req: NewConnection<T, L>) -> Self::Future {
+        let addr = match req.stream.peer_addr() {
+            Ok(addr) => addr,
+            Err(e) => return Either::Right(future::ready(Err(e))),
+        };
+
+        Either::Left(self.inner.call(NewConnection {
+            stream: req.stream,
+            service_builder: req.service_builder.layer(PeerAddrRequestLayer { addr }),
+        }))
+    }
+}
+
+pub struct PeerAddrRequestLayer {
+    addr: SocketAddr,
+}
+
+impl<S> Layer<S> for PeerAddrRequestLayer {
+    type Service = PeerAddrRequestService<S>;
+
+    fn layer(self, inner: S) -> Self::Service {
+        PeerAddrRequestService {
+            inner,
+            addr: self.addr,
+        }
+    }
+}
+
+pub struct PeerAddrRequestService<S> {
+    inner: S,
+    addr: SocketAddr,
+}
+
+impl<S, B> Service<Request<B>> for PeerAddrRequestService<S>
+where
+    S: Service<Request<B>>,
+{
+    type Response = S::Response;
+
+    type Future = S::Future;
+
+    fn call(&self, mut req: Request<B>) -> Self::Future {
+        req.extensions_mut().insert(PeerAddr(self.addr));
+
+        self.inner.call(req)
+    }
+}


### PR DESCRIPTION
This isn't exposed to consumers of Witchcraft - it will be used by audit logging infrastructure to be added in a future PR.

cc #73