### PR TITLE
Update to new conjure APIs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,10 @@ members = [
     "witchcraft-server-ete",
     "witchcraft-server-macros",
 ]
+
+[patch.crates-io]
+conjure-codegen = { git = "https://github.com/palantir/conjure-rust", branch = "response-extensions" }
+conjure-error = { git = "https://github.com/palantir/conjure-rust", branch = "response-extensions" }
+conjure-http = { git = "https://github.com/palantir/conjure-rust", branch = "response-extensions" }
+conjure-object = { git = "https://github.com/palantir/conjure-rust", branch = "response-extensions" }
+conjure-serde = { git = "https://github.com/palantir/conjure-rust", branch = "response-extensions" }

--- a/changelog/@unreleased/pr-77.v2.yml
+++ b/changelog/@unreleased/pr-77.v2.yml
@@ -1,0 +1,5 @@
+type: break
+break:
+  description: Bumped to Conjure 3.
+  links:
+  - https://github.com/palantir/witchcraft-rust-server/pull/77

--- a/witchcraft-server/src/debug/endpoint.rs
+++ b/witchcraft-server/src/debug/endpoint.rs
@@ -20,7 +20,7 @@ use conjure_http::server::{
 };
 use conjure_http::{PathParams, SafeParams};
 use http::header::{HeaderName, AUTHORIZATION, CONTENT_TYPE};
-use http::{HeaderValue, Method, Request, Response};
+use http::{Extensions, HeaderValue, Method, Request, Response};
 use once_cell::sync::Lazy;
 use openssl::memcmp;
 use refreshable::Refreshable;
@@ -108,9 +108,12 @@ impl EndpointMetadata for DiagnosticEndpoint {
 impl AsyncEndpoint<RequestBody, ResponseWriter> for DiagnosticEndpoint {
     async fn handle(
         &self,
-        safe_params: &mut SafeParams,
         req: Request<RequestBody>,
+        response_extensions: &mut Extensions,
     ) -> Result<Response<AsyncResponseBody<ResponseWriter>>, Error> {
+        response_extensions.insert(SafeParams::new());
+        let safe_params = response_extensions.get_mut::<SafeParams>().unwrap();
+
         let diagnostic_type = &req
             .extensions()
             .get::<PathParams>()

--- a/witchcraft-server/src/status.rs
+++ b/witchcraft-server/src/status.rs
@@ -20,10 +20,9 @@ use conjure_error::{Error, PermissionDenied};
 use conjure_http::server::{
     AsyncEndpoint, AsyncResponseBody, AsyncService, EndpointMetadata, PathSegment,
 };
-use conjure_http::SafeParams;
 use conjure_serde::json;
 use http::header::{AUTHORIZATION, CONTENT_TYPE};
-use http::{HeaderValue, Method, Request, Response, StatusCode};
+use http::{Extensions, HeaderValue, Method, Request, Response, StatusCode};
 use openssl::memcmp;
 use refreshable::Refreshable;
 use std::borrow::Cow;
@@ -114,8 +113,8 @@ impl EndpointMetadata for LivenessEndpoint {
 impl AsyncEndpoint<RequestBody, ResponseWriter> for LivenessEndpoint {
     async fn handle(
         &self,
-        _: &mut SafeParams,
         _: Request<RequestBody>,
+        _: &mut Extensions,
     ) -> Result<Response<AsyncResponseBody<ResponseWriter>>, Error> {
         let mut response = Response::new(AsyncResponseBody::Empty);
         *response.status_mut() = StatusCode::NO_CONTENT;
@@ -160,8 +159,8 @@ impl EndpointMetadata for HealthEndpoint {
 impl AsyncEndpoint<RequestBody, ResponseWriter> for HealthEndpoint {
     async fn handle(
         &self,
-        _: &mut SafeParams,
         req: Request<RequestBody>,
+        _: &mut Extensions,
     ) -> Result<Response<AsyncResponseBody<ResponseWriter>>, Error> {
         let authorization = match req.headers().get(AUTHORIZATION) {
             Some(authorization) => authorization,
@@ -232,8 +231,8 @@ impl EndpointMetadata for ReadinessEndpoint {
 impl AsyncEndpoint<RequestBody, ResponseWriter> for ReadinessEndpoint {
     async fn handle(
         &self,
-        _: &mut SafeParams,
         _: Request<RequestBody>,
+        _: &mut Extensions,
     ) -> Result<Response<AsyncResponseBody<ResponseWriter>>, Error> {
         let readiness_checks = task::spawn_blocking({
             let readiness_checks = self.state.readiness_checks.clone();

--- a/witchcraft-server/src/tls/tls_client_authentication.rs
+++ b/witchcraft-server/src/tls/tls_client_authentication.rs
@@ -18,8 +18,7 @@ use conjure_http::server::{
     AsyncEndpoint, AsyncResponseBody, AsyncService, Endpoint, EndpointMetadata, PathSegment,
     ResponseBody, Service,
 };
-use conjure_http::SafeParams;
-use http::{Method, Request, Response};
+use http::{Extensions, Method, Request, Response};
 use openssl::nid::Nid;
 use openssl::stack::Stack;
 use openssl::x509::{GeneralName, X509NameRef};
@@ -192,11 +191,11 @@ where
 {
     fn handle(
         &self,
-        safe_params: &mut SafeParams,
         req: Request<I>,
+        response_extensions: &mut Extensions,
     ) -> Result<Response<ResponseBody<O>>, Error> {
         self.check_request(&req)?;
-        self.inner.handle(safe_params, req)
+        self.inner.handle(req, response_extensions)
     }
 }
 
@@ -208,13 +207,13 @@ where
 {
     async fn handle(
         &self,
-        safe_params: &mut SafeParams,
         req: Request<I>,
+        response_extensions: &mut Extensions,
     ) -> Result<Response<AsyncResponseBody<O>>, Error>
     where
         I: 'async_trait,
     {
         self.check_request(&req)?;
-        self.inner.handle(safe_params, req).await
+        self.inner.handle(req, response_extensions).await
     }
 }


### PR DESCRIPTION
In addition to matching the new Conjure trait definitions, we also now catch panics directly at the Conjure level to ensure that response extensions are propagated even when the handler panics.

cc #73