### PR TITLE
Don't panic on body polls after EOS

### DIFF
--- a/changelog/@unreleased/pr-79.v2.yml
+++ b/changelog/@unreleased/pr-79.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Fixed a panic when reading the request body or writing the response
+    body after an IO error or EOS.
+  links:
+  - https://github.com/palantir/witchcraft-rust-server/pull/79

--- a/witchcraft-server-ete/test-ir.json
+++ b/witchcraft-server-ete/test-ir.json
@@ -163,6 +163,29 @@
       },
       "markers" : [ ],
       "tags" : [ ]
+    }, {
+      "endpointName" : "ioAfterEof",
+      "httpMethod" : "POST",
+      "httpPath" : "/test/ioAfterEof",
+      "args" : [ {
+        "argName" : "body",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "BINARY"
+        },
+        "paramType" : {
+          "type" : "body",
+          "body" : { }
+        },
+        "markers" : [ ],
+        "tags" : [ ]
+      } ],
+      "returns" : {
+        "type" : "primitive",
+        "primitive" : "BINARY"
+      },
+      "markers" : [ ],
+      "tags" : [ ]
     } ]
   } ],
   "extensions" : { }

--- a/witchcraft-server-ete/test.yml
+++ b/witchcraft-server-ete/test.yml
@@ -50,3 +50,8 @@ services:
         args:
           body: binary
         returns: binary
+      ioAfterEof:
+        http: POST /ioAfterEof
+        args:
+          body: binary
+        returns: binary

--- a/witchcraft-server-ete/tests/ete/main.rs
+++ b/witchcraft-server-ete/tests/ete/main.rs
@@ -277,3 +277,27 @@ impl HttpBody for TrailersBody {
         Poll::Ready(Ok(Some(trailers)))
     }
 }
+
+#[tokio::test]
+async fn io_after_eof() {
+    Server::with(|server| async move {
+        let request = Request::builder()
+            .method("POST")
+            .uri("/witchcraft-ete/api/test/ioAfterEof")
+            .header("Content-Type", "application/octet-stream")
+            .body(Body::from("hello world"))
+            .unwrap();
+        let response = server
+            .client()
+            .await
+            .unwrap()
+            .send_request(request)
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        drop(response);
+
+        server.shutdown().await;
+    })
+    .await;
+}

--- a/witchcraft-server/src/service/spans.rs
+++ b/witchcraft-server/src/service/spans.rs
@@ -145,7 +145,12 @@ where
     ) -> Poll<Option<Result<Self::Data, Self::Error>>> {
         let this = self.project();
 
-        let span = this.span.as_mut().unwrap().get();
+        let span = match this.span.as_mut() {
+            Some(span) => span.get(),
+            // Early-exit on polls after error or EOF
+            None => return Poll::Ready(None),
+        };
+
         let _guard = zipkin::set_current(span.context());
 
         let poll = this.inner.poll_data(cx);


### PR DESCRIPTION
## Before this PR
The span tracking body would panic if you called `poll_data` after an IO error or EOS.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Fixed a panic when reading the request body or writing the response body after an IO error or EOS.
==COMMIT_MSG==

We have the conjure bump on develop, so I'll backport to 2.1.x after this lands.

