### PR TITLE
Fix version metadata

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: rust:1.62.0
+      - image: rust:1.64.0
     environment:
       RUSTFLAGS: -D warnings
       # Work around a Clippy ICE :(

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,6 @@
+[workspace.package]
+version = "3.1.0"
+
 [workspace]
 members = [
     "render-conjure",

--- a/changelog/@unreleased/pr-83.v2.yml
+++ b/changelog/@unreleased/pr-83.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fixed publish.
+  links:
+  - https://github.com/palantir/witchcraft-rust-server/pull/83

--- a/render-conjure/Cargo.toml
+++ b/render-conjure/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "render-conjure"
-version = "1.1.0"
+version.workspace = true
 edition = "2021"
 publish = false
 

--- a/witchcraft-server-config/Cargo.toml
+++ b/witchcraft-server-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "witchcraft-server-config"
-version = "2.1.0"
+version.workspace = true
 edition = "2021"
 license = "Apache-2.0"
 description = "Configuration types for witchcraft-server"

--- a/witchcraft-server-config/src/lib.rs
+++ b/witchcraft-server-config/src/lib.rs
@@ -13,6 +13,8 @@
 // limitations under the License.
 //! Witchcraft server configuration.
 #![warn(missing_docs)]
+// We want to be able to add float values to configs in the future
+#![allow(clippy::derive_partial_eq_without_eq)]
 use core::fmt;
 use std::error::Error;
 

--- a/witchcraft-server-ete/Cargo.toml
+++ b/witchcraft-server-ete/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "witchcraft-server-ete"
-version = "1.1.0"
+version.workspace = true
 edition = "2021"
 publish = false
 

--- a/witchcraft-server-macros/Cargo.toml
+++ b/witchcraft-server-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "witchcraft-server-macros"
-version = "2.1.0"
+version.workspace = true
 edition = "2021"
 license = "Apache-2.0"
 description = "Macro definitions used by witchcraft-server"
@@ -19,4 +19,4 @@ syn = { version = "1", features = ["full"] }
 conjure-error = "3"
 refreshable = "1"
 
-witchcraft-server = { version = "2.1.0", path = "../witchcraft-server" }
+witchcraft-server = { version = "3.1.0", path = "../witchcraft-server" }

--- a/witchcraft-server/Cargo.toml
+++ b/witchcraft-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "witchcraft-server"
-version = "2.1.0"
+version.workspace = true
 edition = "2021"
 license = "Apache-2.0"
 description = "A highly opinionated embedded application server for RESTy APIs, compatible with the Witchcraft ecosystem"
@@ -93,8 +93,8 @@ witchcraft-log = "3"
 witchcraft-metrics = "1"
 zipkin = "0.4"
 
-witchcraft-server-config = { version = "2.1.0", path = "../witchcraft-server-config" }
-witchcraft-server-macros = { version = "2.1.0", path = "../witchcraft-server-macros" }
+witchcraft-server-config = { version = "3.1.0", path = "../witchcraft-server-config" }
+witchcraft-server-macros = { version = "3.1.0", path = "../witchcraft-server-macros" }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 procinfo = "0.4"


### PR DESCRIPTION
I forgot to bump the versions to 3.0.0 in #80 :(

I moved the version over to the new workspace inheritance system so it's easier to adjust in the future: https://doc.rust-lang.org/cargo/reference/workspaces.html#the-package-table