### PR TITLE
Expose APIs needed for audit logging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "3.1.0"
+version = "3.2.0"
 
 [workspace]
 members = [

--- a/changelog/@unreleased/pr-84.v2.yml
+++ b/changelog/@unreleased/pr-84.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Exposed all Conjure-generated Witchcraft logging type definitions as
+    well as MDC keys for log-specific fields.
+  links:
+  - https://github.com/palantir/witchcraft-rust-server/pull/84

--- a/witchcraft-server-ete/tests/ete/server/mod.rs
+++ b/witchcraft-server-ete/tests/ete/server/mod.rs
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-use api::{AuditLogV3, LogLevel, RequestLogV2, ServiceLogV1};
 use conjure_serde::json;
 use hyper::body::HttpBody;
 use hyper::client::conn::{self, SendRequest};
@@ -32,11 +31,7 @@ use tokio::net::TcpStream;
 use tokio::sync::oneshot;
 use tokio::{task, time};
 use tokio_openssl::SslStream;
-
-#[allow(warnings)]
-#[rustfmt::skip]
-#[path = "../../../../witchcraft-server/src/logging/api/mod.rs"]
-pub mod api;
+use witchcraft_server::logging::api::{AuditLogV3, LogLevel, RequestLogV2, ServiceLogV1};
 
 // this is a bit racy, but should work in practice
 fn open_port() -> u16 {

--- a/witchcraft-server-macros/Cargo.toml
+++ b/witchcraft-server-macros/Cargo.toml
@@ -19,4 +19,4 @@ syn = { version = "1", features = ["full"] }
 conjure-error = "3"
 refreshable = "1"
 
-witchcraft-server = { version = "3.1.0", path = "../witchcraft-server" }
+witchcraft-server = { version = "3.2.0", path = "../witchcraft-server" }

--- a/witchcraft-server/Cargo.toml
+++ b/witchcraft-server/Cargo.toml
@@ -93,8 +93,8 @@ witchcraft-log = "3"
 witchcraft-metrics = "1"
 zipkin = "0.4"
 
-witchcraft-server-config = { version = "3.1.0", path = "../witchcraft-server-config" }
-witchcraft-server-macros = { version = "3.1.0", path = "../witchcraft-server-macros" }
+witchcraft-server-config = { version = "3.2.0", path = "../witchcraft-server-config" }
+witchcraft-server-macros = { version = "3.2.0", path = "../witchcraft-server-macros" }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 procinfo = "0.4"

--- a/witchcraft-server/src/audit.rs
+++ b/witchcraft-server/src/audit.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Audit log type definitions.
-
 pub use crate::logging::api::{
     audit_log_v3, audit_producer, audit_result, contextualized_user, organization,
     sensitivity_tagged_value, AuditLogV3, AuditProducer, AuditResult, ContextualizedUser,

--- a/witchcraft-server/src/lib.rs
+++ b/witchcraft-server/src/lib.rs
@@ -321,6 +321,9 @@ pub use witchcraft_server_config as config;
 #[doc(inline)]
 pub use witchcraft_server_macros::main;
 
+// FIXME remove in next breaking release
+#[doc(hidden)]
+#[deprecated(note = "Use `logging::api` instead", since = "3.2.0")]
 pub mod audit;
 pub mod blocking;
 mod body;
@@ -329,7 +332,7 @@ mod debug;
 mod endpoint;
 pub mod extensions;
 pub mod health;
-mod logging;
+pub mod logging;
 mod metrics;
 mod minidump;
 pub mod readiness;

--- a/witchcraft-server/src/logging/mdc.rs
+++ b/witchcraft-server/src/logging/mdc.rs
@@ -1,0 +1,30 @@
+// Copyright 2022 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! MDC keys managed by Witchcraft.
+//!
+//! All keys in the `witchcraft_log::mdc` will be included as parameters in service logs emitted
+//! by Witchcraft. However, there are some keys that are treated specially.
+//!
+//! These keys are set automatically by Witchcraft and will be written to specific keys in the log
+//! message rather than the generic params map.
+
+/// The safe MDC key storing the value for the `uid` field in service logs.
+pub const UID_KEY: &str = "\0witchcraft-uid";
+/// The safe MDC key storing the value for the `sid` field in service logs.
+pub const SID_KEY: &str = "\0witchcraft-sid";
+/// The safe MDC key storing the value for the `tokenId` field in service logs.
+pub const TOKEN_ID_KEY: &str = "\0witchcraft-token-id";
+/// The safe MDC key storing the value for the `traceId` field in service logs.
+pub const TRACE_ID_KEY: &str = "\0witchcraft-trace-id";

--- a/witchcraft-server/src/logging/mod.rs
+++ b/witchcraft-server/src/logging/mod.rs
@@ -11,43 +11,43 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+//! Logging APIs
 use crate::logging::api::{AuditLogV3, RequestLogV2};
 use crate::shutdown_hooks::ShutdownHooks;
 use conjure_error::Error;
-pub use logger::{Appender, SyncAppender};
+pub(crate) use logger::{Appender, SyncAppender};
 use refreshable::Refreshable;
 use std::sync::Arc;
 use witchcraft_metrics::MetricRegistry;
 use witchcraft_server_config::install::InstallConfig;
 use witchcraft_server_config::runtime::LoggingConfig;
 
+/// Conjure-generated type definitions for log formats.
 #[allow(warnings)]
 #[rustfmt::skip]
 pub mod api;
 mod cleanup;
 mod format;
 mod logger;
+pub mod mdc;
 mod metric;
 mod service;
 mod trace;
 
-pub const UID_MDC_KEY: &str = "\0witchcraft-uid";
-pub const SID_MDC_KEY: &str = "\0witchcraft-sid";
-pub const TOKEN_ID_MDC_KEY: &str = "\0witchcraft-token-id";
-pub const TRACE_ID_MDC_KEY: &str = "\0witchcraft-trace-id";
-pub const REQUEST_ID_KEY: &str = "_requestId";
-pub const SAMPLED_KEY: &str = "_sampled";
+pub(crate) const REQUEST_ID_KEY: &str = "_requestId";
+pub(crate) const SAMPLED_KEY: &str = "_sampled";
 
-pub struct Loggers {
+pub(crate) struct Loggers {
     pub request_logger: Appender<RequestLogV2>,
     pub audit_logger: SyncAppender<AuditLogV3>,
 }
 
-pub fn early_init() {
+pub(crate) fn early_init() {
     service::early_init()
 }
 
-pub async fn init(
+pub(crate) async fn init(
     metrics: &Arc<MetricRegistry>,
     install: &InstallConfig,
     runtime: &Refreshable<LoggingConfig, Error>,

--- a/witchcraft-server/src/logging/service.rs
+++ b/witchcraft-server/src/logging/service.rs
@@ -115,22 +115,22 @@ impl Log for ServiceLogger {
         let mdc = mdc::snapshot();
         for (key, value) in mdc.safe().iter() {
             match key {
-                logging::UID_MDC_KEY => {
+                logging::mdc::UID_KEY => {
                     if let Ok(uid) = String::deserialize(value.clone()) {
                         message = message.uid(UserId(uid));
                     }
                 }
-                logging::SID_MDC_KEY => {
+                logging::mdc::SID_KEY => {
                     if let Ok(sid) = String::deserialize(value.clone()) {
                         message = message.sid(SessionId(sid));
                     }
                 }
-                logging::TOKEN_ID_MDC_KEY => {
+                logging::mdc::TOKEN_ID_KEY => {
                     if let Ok(token_id) = String::deserialize(value.clone()) {
                         message = message.token_id(TokenId(token_id));
                     }
                 }
-                logging::TRACE_ID_MDC_KEY => {
+                logging::mdc::TRACE_ID_KEY => {
                     if let Ok(trace_id) = String::deserialize(value.clone()) {
                         message = message.trace_id(TraceId(trace_id));
                     }

--- a/witchcraft-server/src/server.rs
+++ b/witchcraft-server/src/server.rs
@@ -58,7 +58,7 @@ use witchcraft_log::debug;
 
 pub type RawBody = RequestLogRequestBody<SpannedBody<hyper::Body>>;
 
-pub async fn start(
+pub(crate) async fn start(
     witchcraft: &mut Witchcraft,
     shutdown_hooks: &mut ShutdownHooks,
     loggers: Loggers,

--- a/witchcraft-server/src/service/request_log.rs
+++ b/witchcraft-server/src/service/request_log.rs
@@ -121,19 +121,19 @@ where
         let mdc = mdc::snapshot();
         let uid = mdc
             .safe()
-            .get(logging::UID_MDC_KEY)
+            .get(logging::mdc::UID_KEY)
             .and_then(|v| UserId::deserialize(v.clone()).ok());
         let sid = mdc
             .safe()
-            .get(logging::SID_MDC_KEY)
+            .get(logging::mdc::SID_KEY)
             .and_then(|v| SessionId::deserialize(v.clone()).ok());
         let token_id = mdc
             .safe()
-            .get(logging::TOKEN_ID_MDC_KEY)
+            .get(logging::mdc::TOKEN_ID_KEY)
             .and_then(|v| TokenId::deserialize(v.clone()).ok());
         let trace_id = mdc
             .safe()
-            .get(logging::TRACE_ID_MDC_KEY)
+            .get(logging::mdc::TRACE_ID_KEY)
             .and_then(|v| TraceId::deserialize(v.clone()).ok());
 
         let mut params = vec![];

--- a/witchcraft-server/src/service/witchcraft_mdc.rs
+++ b/witchcraft-server/src/service/witchcraft_mdc.rs
@@ -46,17 +46,17 @@ where
 
     fn call(&self, req: Request<B>) -> Self::Future {
         if let Some(jwt) = req.extensions().get::<UnverifiedJwt>() {
-            mdc::insert_safe(logging::UID_MDC_KEY, jwt.unverified_user_id());
+            mdc::insert_safe(logging::mdc::UID_KEY, jwt.unverified_user_id());
             if let Some(session_id) = jwt.unverified_session_id() {
-                mdc::insert_safe(logging::SID_MDC_KEY, session_id);
+                mdc::insert_safe(logging::mdc::SID_KEY, session_id);
             }
             if let Some(token_id) = jwt.unverified_token_id() {
-                mdc::insert_safe(logging::TOKEN_ID_MDC_KEY, token_id);
+                mdc::insert_safe(logging::mdc::TOKEN_ID_KEY, token_id);
             }
         }
 
         let context = zipkin::current().expect("zipkin trace not initialized");
-        mdc::insert_safe(logging::TRACE_ID_MDC_KEY, context.trace_id().to_string());
+        mdc::insert_safe(logging::mdc::TRACE_ID_KEY, context.trace_id().to_string());
         if let Some(sampled) = context.sampled() {
             mdc::insert_safe(logging::SAMPLED_KEY, sampled);
         }


### PR DESCRIPTION
## Before this PR
#80 neglected to expose some of the Conjure-generated types needed for AuditLogV3 (`SessionId`, etc). It also didn't provide access to the UID, SID, or TokenId values for manually constructed audit logs.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Exposed all Conjure-generated Witchcraft logging type definitions as well as MDC keys for log-specific fields.
==COMMIT_MSG==

## Possible downsides?
Exposing all of the logging APIs is more than is necessary for audit log construction but it seems like it's just a bit overly fragile to try to expose exactly the minimal subset.

