### PR TITLE
Ensure each response body chunk is decompressable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: rust:1.64.0
+      - image: rust:1.65.0
     environment:
       RUSTFLAGS: -D warnings
       # Work around a Clippy ICE :(

--- a/changelog/@unreleased/pr-93.v2.yml
+++ b/changelog/@unreleased/pr-93.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Fixed a bug where compressed response body chunks couldn't be decompressed
+    until the next chunk was received.
+  links:
+  - https://github.com/palantir/witchcraft-rust-server/pull/93

--- a/witchcraft-server/Cargo.toml
+++ b/witchcraft-server/Cargo.toml
@@ -40,6 +40,7 @@ conjure-object = "3"
 conjure-runtime = "4"
 conjure-serde = "3"
 crash-handler = "0.4"
+flate2 = "1"
 foreign-types = "0.5"
 futures-channel = "0.3"
 futures-sink = "0.3"
@@ -101,6 +102,5 @@ procinfo = "0.4"
 rstack-self = { version = "0.3", features = ["dw"], default-features = false }
 
 [dev-dependencies]
-flate2 = "1"
 tempfile = "3"
 tokio = { version = "1", features = ["test-util"] }

--- a/witchcraft-server/Cargo.toml
+++ b/witchcraft-server/Cargo.toml
@@ -87,7 +87,7 @@ tokio = { version = "1", features = [
     "time",
 ] }
 tokio-openssl = "0.6"
-tokio-util = { version = "0.7", features = ["codec"] }
+tokio-util = "0.7"
 tracing = { version = "0.1", features = ["log"] }
 typed-arena = "2"
 witchcraft-log = "3"

--- a/witchcraft-server/src/service/spans.rs
+++ b/witchcraft-server/src/service/spans.rs
@@ -106,7 +106,7 @@ impl LazySpan {
                         Some(context) => zipkin::new_child(*context),
                         None => zipkin::new_trace(),
                     };
-                    let span = span.with_name(*name).detach();
+                    let span = span.with_name(name).detach();
                     *self = LazySpan::Live(span);
                 }
                 LazySpan::Live(span) => return span,


### PR DESCRIPTION
## Before this PR
A single chunk of a compressed response body wouldn't be decompressable until the next chunk was received.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Fixed a bug where compressed response body chunks couldn't be decompressed until the next chunk was received.
==COMMIT_MSG==

Rather than a lot of complex wrappping with the async-compression types, we simply keep an encoder off to the side and feed the raw chunks through it. This simplifies the code and gives us more control over when the encoder is flushed.