### PR TITLE
Expose add_shutdown_hook to register server shutdown futures

### DIFF
--- a/changelog/@unreleased/pr-103.v2.yml
+++ b/changelog/@unreleased/pr-103.v2.yml
@@ -1,0 +1,8 @@
+type: feature
+feature:
+  description: |-
+    Expose add_shutdown_hook to register server shutdown futures
+
+    Adds a `add_shutdown_hook` method to Witchcraft that allows callers to register a future that will be polled until ready when the server shuts down.
+  links:
+  - https://github.com/palantir/witchcraft-rust-server/pull/103

--- a/changelog/@unreleased/pr-103.v2.yml
+++ b/changelog/@unreleased/pr-103.v2.yml
@@ -1,8 +1,6 @@
 type: feature
 feature:
   description: |-
-    Expose add_shutdown_hook to register server shutdown futures
-
-    Adds a `add_shutdown_hook` method to Witchcraft that allows callers to register a future that will be polled until ready when the server shuts down.
+    Expose`on_shutdown` method in Witchcraft to register server shutdown operations.
   links:
   - https://github.com/palantir/witchcraft-rust-server/pull/103

--- a/witchcraft-server/src/lib.rs
+++ b/witchcraft-server/src/lib.rs
@@ -458,6 +458,7 @@ where
         install_config: install_config.as_ref().clone(),
         thread_pool: None,
         endpoints: vec![],
+        shutdown_hooks: ShutdownHooks::new(),
     };
 
     let status_endpoints = StatusEndpoints::new(
@@ -476,15 +477,10 @@ where
         .health_checks
         .register(Endpoint500sHealthCheck::new(&witchcraft.endpoints));
 
-    let mut server_shutdown_hooks = ShutdownHooks::new();
-    handle.block_on(server::start(
-        &mut witchcraft,
-        &mut server_shutdown_hooks,
-        loggers,
-    ))?;
+    handle.block_on(server::start(&mut witchcraft, loggers))?;
 
     handle.block_on(shutdown(
-        server_shutdown_hooks,
+        witchcraft.shutdown_hooks,
         witchcraft.install_config.server().shutdown_timeout(),
     ))
 }

--- a/witchcraft-server/src/server.rs
+++ b/witchcraft-server/src/server.rs
@@ -46,7 +46,6 @@ use crate::service::unverified_jwt::UnverifiedJwtLayer;
 use crate::service::web_security::WebSecurityLayer;
 use crate::service::witchcraft_mdc::WitchcraftMdcLayer;
 use crate::service::{Service, ServiceBuilder};
-use crate::shutdown_hooks::ShutdownHooks;
 use crate::Witchcraft;
 use conjure_error::Error;
 use std::future::Future;
@@ -58,11 +57,7 @@ use witchcraft_log::debug;
 
 pub type RawBody = RequestLogRequestBody<SpannedBody<hyper::Body>>;
 
-pub(crate) async fn start(
-    witchcraft: &mut Witchcraft,
-    shutdown_hooks: &mut ShutdownHooks,
-    loggers: Loggers,
-) -> Result<(), Error> {
+pub(crate) async fn start(witchcraft: &mut Witchcraft, loggers: Loggers) -> Result<(), Error> {
     // This service handles individual HTTP requests, each running concurrently.
     let request_service = ServiceBuilder::new()
         .layer(RoutingLayer::new(mem::take(&mut witchcraft.endpoints)))
@@ -95,7 +90,7 @@ pub(crate) async fn start(
         .layer(TlsLayer::new(&witchcraft.install_config)?)
         .layer(TlsMetricsLayer::new(&witchcraft.metrics))
         .layer(ClientCertificateLayer)
-        .layer(GracefulShutdownLayer::new(shutdown_hooks))
+        .layer(GracefulShutdownLayer::new(&mut witchcraft.shutdown_hooks))
         .layer(IdleConnectionLayer::new(&witchcraft.install_config))
         .service(HyperService::new(request_service));
     let handle_service = Arc::new(handle_service);
@@ -132,7 +127,7 @@ pub(crate) async fn start(
         }
     });
 
-    shutdown_hooks.push(async move {
+    witchcraft.add_shutdown_hook(async move {
         handle.abort();
     });
 

--- a/witchcraft-server/src/server.rs
+++ b/witchcraft-server/src/server.rs
@@ -127,7 +127,7 @@ pub(crate) async fn start(witchcraft: &mut Witchcraft, loggers: Loggers) -> Resu
         }
     });
 
-    witchcraft.add_shutdown_hook(async move {
+    witchcraft.on_shutdown(async move {
         handle.abort();
     });
 

--- a/witchcraft-server/src/shutdown_hooks.rs
+++ b/witchcraft-server/src/shutdown_hooks.rs
@@ -32,8 +32,7 @@ impl ShutdownHooks {
         }
     }
 
-    #[allow(dead_code)]
-    pub fn push<F>(&mut self, future: F)
+    pub(crate) fn push<F>(&mut self, future: F)
     where
         F: Future<Output = ()> + 'static + Send,
     {

--- a/witchcraft-server/src/shutdown_hooks.rs
+++ b/witchcraft-server/src/shutdown_hooks.rs
@@ -32,7 +32,8 @@ impl ShutdownHooks {
         }
     }
 
-    pub(crate) fn push<F>(&mut self, future: F)
+    #[allow(dead_code)]
+    pub fn push<F>(&mut self, future: F)
     where
         F: Future<Output = ()> + 'static + Send,
     {

--- a/witchcraft-server/src/witchcraft.rs
+++ b/witchcraft-server/src/witchcraft.rs
@@ -143,8 +143,9 @@ impl Witchcraft {
         )
     }
 
-    /// Adds a future that will be polled until ready when the server shuts down
-    pub fn add_shutdown_hook<F>(&mut self, future: F)
+    /// Adds a future that will be polled until ready when the server shuts down. 
+    /// The future will be polled for a limited time until an install configured shutdown duration has elapsed. 
+    pub fn on_shutdown<F>(&mut self, future: F)
     where
         F: Future<Output = ()> + 'static + Send,
     {

--- a/witchcraft-server/src/witchcraft.rs
+++ b/witchcraft-server/src/witchcraft.rs
@@ -143,8 +143,8 @@ impl Witchcraft {
         )
     }
 
-    /// Adds a future that will be polled when the server shuts down. 
-    /// The future will be polled until it is ready or the server shutdown duration has elapsed. 
+    /// Adds a future that will be polled when the server shuts down.
+    /// The future will be polled until it is ready or the server shutdown duration has elapsed.
     pub fn on_shutdown<F>(&mut self, future: F)
     where
         F: Future<Output = ()> + 'static + Send,

--- a/witchcraft-server/src/witchcraft.rs
+++ b/witchcraft-server/src/witchcraft.rs
@@ -18,9 +18,11 @@ use crate::endpoint::extended_path::ExtendedPathEndpoint;
 use crate::endpoint::WitchcraftEndpoint;
 use crate::health::HealthCheckRegistry;
 use crate::readiness::ReadinessCheckRegistry;
+use crate::shutdown_hooks::ShutdownHooks;
 use crate::{blocking, RequestBody, ResponseWriter};
 use conjure_http::server::{AsyncEndpoint, AsyncService, Endpoint, Service};
 use conjure_runtime::ClientFactory;
+use futures_util::Future;
 use std::sync::Arc;
 use tokio::runtime::Handle;
 use witchcraft_metrics::MetricRegistry;
@@ -36,6 +38,7 @@ pub struct Witchcraft {
     pub(crate) install_config: InstallConfig,
     pub(crate) thread_pool: Option<Arc<ThreadPool>>,
     pub(crate) endpoints: Vec<Box<dyn WitchcraftEndpoint + Sync + Send>>,
+    pub(crate) shutdown_hooks: ShutdownHooks,
 }
 
 impl Witchcraft {
@@ -138,6 +141,14 @@ impl Witchcraft {
                 .map(|e| Box::new(ConjureBlockingEndpoint::new(&self.metrics, thread_pool, e)))
                 .map(|e| extend_path(e, self.install_config.context_path(), prefix)),
         )
+    }
+
+    /// Adds a future that will be polled until ready when the server shuts down
+    pub fn add_shutdown_hook<F>(&mut self, future: F)
+    where
+        F: Future<Output = ()> + 'static + Send,
+    {
+        self.shutdown_hooks.push(future)
     }
 }
 

--- a/witchcraft-server/src/witchcraft.rs
+++ b/witchcraft-server/src/witchcraft.rs
@@ -143,8 +143,9 @@ impl Witchcraft {
         )
     }
 
-    /// Adds a future that will be polled when the server shuts down.
-    /// The future will be polled until it is ready or the server shutdown duration has elapsed.
+    /// Adds a future that will be run when the server begins its shutdown process.
+    ///
+    /// The server will not shut down until the future completes or the configured shutdown timeout elapses.
     pub fn on_shutdown<F>(&mut self, future: F)
     where
         F: Future<Output = ()> + 'static + Send,

--- a/witchcraft-server/src/witchcraft.rs
+++ b/witchcraft-server/src/witchcraft.rs
@@ -143,8 +143,8 @@ impl Witchcraft {
         )
     }
 
-    /// Adds a future that will be polled until ready when the server shuts down. 
-    /// The future will be polled for a limited time until an install configured shutdown duration has elapsed. 
+    /// Adds a future that will be polled when the server shuts down. 
+    /// The future will be polled until it is ready or the server shutdown duration has elapsed. 
     pub fn on_shutdown<F>(&mut self, future: F)
     where
         F: Future<Output = ()> + 'static + Send,


### PR DESCRIPTION
Adds a `add_shutdown_hook` method to Witchcraft that allows callers to register a future that will be polled until ready when the server shuts down. 

Closes #53 
