### PR TITLE
Switch from OpenSSL to rustls

### DIFF
--- a/changelog/@unreleased/pr-114.v2.yml
+++ b/changelog/@unreleased/pr-114.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: The server now uses rustls as its TLS implementation. The `TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384`
+    and `TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384` cipher suites are no longer supported.
+  links:
+  - https://github.com/palantir/witchcraft-rust-server/pull/114

--- a/witchcraft-server/Cargo.toml
+++ b/witchcraft-server/Cargo.toml
@@ -57,12 +57,13 @@ minidump-processor = "0.15"
 minidumper = "0.7"
 num_cpus = "1"
 once_cell = "1"
-openssl = "0.10"
 parking_lot = "0.12"
 pin-project = "1"
 rand = "0.8"
 refreshable = "1"
 regex = "1"
+rustls-pemfile = "1"
+rustls-webpki = "0.100"
 rustc-demangle = "0.1"
 serde = "1"
 serde-encrypted-value = "0.4"
@@ -71,6 +72,7 @@ serde_yaml = "0.9"
 sequence_trie = "0.3"
 socket2 = "0.5"
 staged-builder = "0.1.1"
+subtle = "2.5"
 symbolic = { version = "12", features = ["cfi", "debuginfo"] }
 sync_wrapper = "0.1"
 tikv-jemalloc-ctl = { version = "0.5", features = ["use_std"], optional = true }
@@ -86,7 +88,7 @@ tokio = { version = "1.27", features = [
     "signal",
     "time",
 ] }
-tokio-openssl = "0.6"
+tokio-rustls = "0.24"
 tokio-util = "0.7"
 tracing = { version = "0.1", features = ["log"] }
 typed-arena = "2"

--- a/witchcraft-server/src/metrics/proc.rs
+++ b/witchcraft-server/src/metrics/proc.rs
@@ -62,6 +62,7 @@ impl Rlimit {
         }
     }
 
+    #[allow(clippy::unnecessary_cast)]
     pub fn cur(&self) -> u64 {
         self.0.rlim_cur as u64
     }

--- a/witchcraft-server/src/service/tls.rs
+++ b/witchcraft-server/src/service/tls.rs
@@ -165,6 +165,7 @@ where
     }
 }
 
+#[allow(clippy::large_enum_variant)]
 #[pin_project(project = TlsFutureProj)]
 pub enum TlsFuture<S, R, L>
 where

--- a/witchcraft-server/src/service/tls.rs
+++ b/witchcraft-server/src/service/tls.rs
@@ -15,94 +15,119 @@ use crate::service::hyper::NewConnection;
 use crate::service::{Layer, Service, ServiceBuilder};
 use conjure_error::Error;
 use futures_util::ready;
-use openssl::rand;
-use openssl::ssl::{
-    self, AlpnError, Ssl, SslContext, SslFiletype, SslMethod, SslOptions, SslVerifyMode, SslVersion,
-};
 use pin_project::pin_project;
+use rustls_pemfile::Item;
+use std::fs::File;
 use std::future::Future;
+use std::io::BufReader;
+use std::path::Path;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 use tokio::io::{AsyncRead, AsyncWrite};
-use tokio_openssl::SslStream;
+use tokio_rustls::rustls::cipher_suite::{
+    TLS13_AES_128_GCM_SHA256, TLS13_AES_256_GCM_SHA384, TLS13_CHACHA20_POLY1305_SHA256,
+    TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+    TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256, TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+    TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+};
+use tokio_rustls::rustls::kx_group::{SECP256R1, SECP384R1, X25519};
+use tokio_rustls::rustls::server::AllowAnyAnonymousOrAuthenticatedClient;
+use tokio_rustls::rustls::version::{TLS12, TLS13};
+use tokio_rustls::rustls::{
+    Certificate, PrivateKey, RootCertStore, ServerConfig, SupportedCipherSuite, SupportedKxGroup,
+    SupportedProtocolVersion,
+};
+use tokio_rustls::server::TlsStream;
+use tokio_rustls::{Accept, TlsAcceptor};
 use witchcraft_server_config::install::InstallConfig;
 
-const CIPHER_SUITES: &[&str] = &[
-    "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
-    "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
-    "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
-    "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384",
-    "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
-    "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
-    "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
-    "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384",
+static CIPHER_SUITES: [SupportedCipherSuite; 9] = [
+    TLS13_AES_256_GCM_SHA384,
+    TLS13_AES_128_GCM_SHA256,
+    TLS13_CHACHA20_POLY1305_SHA256,
+    TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+    TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+    TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+    TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+    TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+    TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
 ];
 
-const TLS13_CIPHER_SUITES: &[&str] = &[
-    "TLS_AES_256_GCM_SHA384",
-    "TLS_AES_128_GCM_SHA256",
-    "TLS_CHACHA20_POLY1305_SHA256",
-];
+static KX_GROUPS: [&SupportedKxGroup; 3] = [&SECP256R1, &SECP384R1, &X25519];
+
+static PROTOCOL_VERSIONS: [&SupportedProtocolVersion; 2] = [&TLS12, &TLS13];
 
 /// A layer which wraps streams in a TLS session.
 pub struct TlsLayer {
-    context: SslContext,
+    acceptor: TlsAcceptor,
 }
 
 impl TlsLayer {
     pub fn new(config: &InstallConfig) -> Result<Self, Error> {
-        let mut builder = SslContext::builder(SslMethod::tls()).map_err(Error::internal_safe)?;
-
-        builder
-            .set_certificate_chain_file(config.keystore().cert_path())
-            .map_err(Error::internal_safe)?;
-        builder
-            .set_private_key_file(config.keystore().key_path(), SslFiletype::PEM)
-            .map_err(Error::internal_safe)?;
-        builder.check_private_key().map_err(Error::internal_safe)?;
-
-        if let Some(client_auth) = config.client_auth_truststore() {
-            builder
-                .set_ca_file(client_auth.path())
-                .map_err(Error::internal_safe)?;
-
-            builder.set_verify(SslVerifyMode::PEER);
-        }
-
-        let cipher_list = convert_suites(CIPHER_SUITES);
-        builder
-            .set_cipher_list(&cipher_list)
+        let builder = ServerConfig::builder()
+            .with_cipher_suites(&CIPHER_SUITES)
+            .with_kx_groups(&KX_GROUPS)
+            .with_protocol_versions(&PROTOCOL_VERSIONS)
             .map_err(Error::internal_safe)?;
 
-        let ciphersuites = convert_suites(TLS13_CIPHER_SUITES);
-        builder
-            .set_ciphersuites(&ciphersuites)
+        let builder = match config.client_auth_truststore() {
+            Some(client_auth_truststore) => {
+                let certs = load_certificates(client_auth_truststore.path())?;
+                let mut store = RootCertStore::empty();
+                store.add_parsable_certificates(&certs);
+                builder.with_client_cert_verifier(Arc::new(
+                    AllowAnyAnonymousOrAuthenticatedClient::new(store),
+                ))
+            }
+            None => builder.with_no_client_auth(),
+        };
+
+        let cert_chain = load_certificates(config.keystore().cert_path())?
+            .into_iter()
+            .map(Certificate)
+            .collect();
+
+        let key_der = load_private_key(config.keystore().key_path())?;
+
+        let mut server_config = builder
+            .with_single_cert(cert_chain, key_der)
             .map_err(Error::internal_safe)?;
 
+        server_config.ignore_client_order = true;
         if config.server().http2() {
-            builder.set_alpn_select_callback(|_, client| {
-                ssl::select_next_proto(b"\x02h2\x08http/1.1", client).ok_or(AlpnError::ALERT_FATAL)
-            });
+            server_config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
         }
-
-        builder.set_options(SslOptions::CIPHER_SERVER_PREFERENCE);
-        builder
-            .set_min_proto_version(Some(SslVersion::TLS1_2))
-            .map_err(Error::internal_safe)?;
-        builder
-            .set_max_proto_version(Some(SslVersion::TLS1_3))
-            .map_err(Error::internal_safe)?;
-
-        let mut session_id_ctx = [0; 32];
-        rand::rand_bytes(&mut session_id_ctx).map_err(Error::internal_safe)?;
-        builder
-            .set_session_id_context(&session_id_ctx)
-            .map_err(Error::internal_safe)?;
 
         Ok(TlsLayer {
-            context: builder.build(),
+            acceptor: TlsAcceptor::from(Arc::new(server_config)),
         })
+    }
+}
+
+fn load_certificates(path: &Path) -> Result<Vec<Vec<u8>>, Error> {
+    let file = File::open(path).map_err(Error::internal_safe)?;
+    let mut reader = BufReader::new(file);
+    rustls_pemfile::certs(&mut reader).map_err(Error::internal_safe)
+}
+
+fn load_private_key(path: &Path) -> Result<PrivateKey, Error> {
+    let file = File::open(path).map_err(Error::internal_safe)?;
+    let mut reader = BufReader::new(file);
+
+    let mut items = rustls_pemfile::read_all(&mut reader).map_err(Error::internal_safe)?;
+
+    if items.len() != 1 {
+        return Err(Error::internal_safe(
+            "expected exactly one private key in key file",
+        ));
+    }
+
+    match items.pop().unwrap() {
+        Item::RSAKey(buf) | Item::PKCS8Key(buf) | Item::ECKey(buf) => Ok(PrivateKey(buf)),
+        _ => Err(Error::internal_safe(
+            "expected a PKCS#1, PKCS#8, or Sec1 private key",
+        )),
     }
 }
 
@@ -112,19 +137,19 @@ impl<S> Layer<S> for TlsLayer {
     fn layer(self, inner: S) -> Self::Service {
         TlsService {
             inner: Arc::new(inner),
-            context: self.context,
+            acceptor: self.acceptor,
         }
     }
 }
 
 pub struct TlsService<S> {
     inner: Arc<S>,
-    context: SslContext,
+    acceptor: TlsAcceptor,
 }
 
 impl<S, R, L> Service<NewConnection<R, L>> for TlsService<S>
 where
-    S: Service<NewConnection<SslStream<R>, L>, Response = Result<(), Error>>,
+    S: Service<NewConnection<TlsStream<R>, L>, Response = Result<(), Error>>,
     R: AsyncRead + AsyncWrite + Unpin,
 {
     type Response = S::Response;
@@ -132,15 +157,10 @@ where
     type Future = TlsFuture<S, R, L>;
 
     fn call(&self, req: NewConnection<R, L>) -> Self::Future {
-        match Ssl::new(&self.context).and_then(|ssl| SslStream::new(ssl, req.stream)) {
-            Ok(stream) => TlsFuture::Handshaking {
-                stream: Some(stream),
-                service_builder: Some(req.service_builder),
-                inner: self.inner.clone(),
-            },
-            Err(e) => TlsFuture::Error {
-                error: Some(Error::internal_safe(e)),
-            },
+        TlsFuture::Handshaking {
+            accept: self.acceptor.accept(req.stream),
+            service_builder: Some(req.service_builder),
+            inner: self.inner.clone(),
         }
     }
 }
@@ -148,10 +168,10 @@ where
 #[pin_project(project = TlsFutureProj)]
 pub enum TlsFuture<S, R, L>
 where
-    S: Service<NewConnection<SslStream<R>, L>>,
+    S: Service<NewConnection<TlsStream<R>, L>>,
 {
     Handshaking {
-        stream: Option<SslStream<R>>,
+        accept: Accept<R>,
         service_builder: Option<ServiceBuilder<L>>,
         inner: Arc<S>,
     },
@@ -159,14 +179,11 @@ where
         #[pin]
         future: S::Future,
     },
-    Error {
-        error: Option<Error>,
-    },
 }
 
 impl<S, R, L> Future for TlsFuture<S, R, L>
 where
-    S: Service<NewConnection<SslStream<R>, L>, Response = Result<(), Error>>,
+    S: Service<NewConnection<TlsStream<R>, L>, Response = Result<(), Error>>,
     R: AsyncRead + AsyncWrite + Unpin,
 {
     type Output = Result<(), Error>;
@@ -176,13 +193,13 @@ where
             match self.as_mut().project() {
                 TlsFutureProj::Handshaking {
                     inner,
-                    stream,
+                    accept,
                     service_builder,
-                } => match ready!(Pin::new(stream.as_mut().unwrap()).poll_accept(cx)) {
-                    Ok(()) => {
+                } => match ready!(Pin::new(accept).poll(cx)) {
+                    Ok(stream) => {
                         let new = TlsFuture::Inner {
                             future: inner.call(NewConnection {
-                                stream: stream.take().unwrap(),
+                                stream,
                                 service_builder: service_builder.take().unwrap(),
                             }),
                         };
@@ -191,19 +208,7 @@ where
                     Err(e) => return Poll::Ready(Err(Error::internal_safe(e))),
                 },
                 TlsFutureProj::Inner { future } => return future.poll(cx),
-                TlsFutureProj::Error { error } => return Poll::Ready(Err(error.take().unwrap())),
             }
         }
     }
-}
-
-fn convert_suites(suites: &[&str]) -> String {
-    suites
-        .iter()
-        .filter_map(|s| match ssl::cipher_name(s) {
-            "(NONE)" => None,
-            s => Some(s),
-        })
-        .collect::<Vec<_>>()
-        .join(":")
 }

--- a/witchcraft-server/src/tls/client_certificate.rs
+++ b/witchcraft-server/src/tls/client_certificate.rs
@@ -11,7 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-use openssl::x509::{X509Ref, X509};
+
+use tokio_rustls::rustls::Certificate;
 
 /// A client's identity provided during the TLS handshake.
 ///
@@ -19,16 +20,16 @@ use openssl::x509::{X509Ref, X509};
 /// to the extensions of each request made on that connection.
 #[derive(Clone)]
 pub struct ClientCertificate {
-    cert: X509,
+    cert: Certificate,
 }
 
-// FIXME(sfackler) what accessors should we expose here? We probably want to avoid exposing `openssl` APIs directly.
+// FIXME(sfackler) what accessors should we expose here? We probably want to avoid exposing `rustls` APIs directly.
 impl ClientCertificate {
-    pub(crate) fn new(cert: X509) -> Self {
+    pub(crate) fn new(cert: Certificate) -> Self {
         ClientCertificate { cert }
     }
 
-    pub(crate) fn x509(&self) -> &X509Ref {
+    pub(crate) fn cert(&self) -> &Certificate {
         &self.cert
     }
 }


### PR DESCRIPTION
## Before this PR
We used OpenSSL for our TLS and a few other misc crypto operations. It is one of the two remaining native dependencies a witchcraft-rust-server has in addition to elfutils.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
The server now uses rustls as its TLS implementation. The `TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384` and `TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384` cipher suites are no longer supported.
==COMMIT_MSG==

conjure-rust-runtime still uses OpenSSL for now. I'll let this roll out for a bit to make sure there are no fires and then switch over to rustls there as well.

## Possible downsides?
rustls is more pedantic than OpenSSL about supporting slightly out of spec requests. The risk should be low however since our services should only be connecting to things we control (i.e. our other internal services or our proxy infrastructure).

WC-Java has dropped support for the CBC suites a while ago, so that should be safe.