### PR TITLE
Make PeerAddr constructable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "3.4.0"
+version = "3.5.0"
 
 [workspace]
 members = [

--- a/changelog/@unreleased/pr-120.v2.yml
+++ b/changelog/@unreleased/pr-120.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: '`PeerAddr`''s field is now public.'
+  links:
+  - https://github.com/palantir/witchcraft-rust-server/pull/120

--- a/witchcraft-server-macros/Cargo.toml
+++ b/witchcraft-server-macros/Cargo.toml
@@ -19,4 +19,4 @@ syn = { version = "2", features = ["full"] }
 conjure-error = "3"
 refreshable = "1"
 
-witchcraft-server = { version = "3.4.0", path = "../witchcraft-server" }
+witchcraft-server = { version = "3.5.0", path = "../witchcraft-server" }

--- a/witchcraft-server/Cargo.toml
+++ b/witchcraft-server/Cargo.toml
@@ -94,8 +94,8 @@ witchcraft-log = "3"
 witchcraft-metrics = "1"
 zipkin = "0.4"
 
-witchcraft-server-config = { version = "3.4.0", path = "../witchcraft-server-config" }
-witchcraft-server-macros = { version = "3.4.0", path = "../witchcraft-server-macros" }
+witchcraft-server-config = { version = "3.5.0", path = "../witchcraft-server-config" }
+witchcraft-server-macros = { version = "3.5.0", path = "../witchcraft-server-macros" }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 rstack-self = { version = "0.3", features = ["dw"], default-features = false }

--- a/witchcraft-server/src/extensions.rs
+++ b/witchcraft-server/src/extensions.rs
@@ -22,7 +22,7 @@ use std::ops::Deref;
 ///
 /// It will be present in the extensions of every request.
 #[derive(Copy, Clone)]
-pub struct PeerAddr(pub(crate) SocketAddr);
+pub struct PeerAddr(pub SocketAddr);
 
 impl Deref for PeerAddr {
     type Target = SocketAddr;


### PR DESCRIPTION
## Before this PR
PeerAddr could only be constructed in witchcraft-server, which made testing libraries that expect it to be present awkward.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
`PeerAddr`'s field is now public.
==COMMIT_MSG==

## Possible downsides?
In theory we could want to add another field to this type in the future which this change would prevent, but I can't imagine what that would be - the purpose of `PeerAddr` is just to expose the peer's socket address.
