### PR TITLE
fix diagnostic name

### DIFF
--- a/changelog/@unreleased/pr-124.v2.yml
+++ b/changelog/@unreleased/pr-124.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix the heap stats diagnostic name in manifest extension
+  links:
+  - https://github.com/palantir/witchcraft-rust-server/pull/124

--- a/witchcraft-server/Cargo.toml
+++ b/witchcraft-server/Cargo.toml
@@ -16,7 +16,7 @@ type = "metric.names.v1"
 docs = "All currently emitted metrics and their tags."
 
 [[package.metadata.sls.diagnostics]]
-type = "rust.heap.status.v1"
+type = "rust.heap.stats.v1"
 docs = "Statistics about the memory allocator, in jemalloc's default text format."
 
 [[package.metadata.sls.diagnostics]]


### PR DESCRIPTION
## Before this PR
Reporting the wrong diagnostic name in manifest extension
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Fix the heap stats diagnostic name in manifest extension
==COMMIT_MSG==
