### PR TITLE
bump version to 3.7.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "3.5.0"
+version = "3.7.0"
 
 [workspace]
 members = [

--- a/changelog/@unreleased/pr-126.v2.yml
+++ b/changelog/@unreleased/pr-126.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: bump version to 3.7.0
+  links:
+  - https://github.com/palantir/witchcraft-rust-server/pull/126

--- a/witchcraft-server-macros/Cargo.toml
+++ b/witchcraft-server-macros/Cargo.toml
@@ -19,4 +19,4 @@ syn = { version = "2", features = ["full"] }
 conjure-error = "3"
 refreshable = "1"
 
-witchcraft-server = { version = "3.5.0", path = "../witchcraft-server" }
+witchcraft-server = { version = "3.7.0", path = "../witchcraft-server" }

--- a/witchcraft-server/Cargo.toml
+++ b/witchcraft-server/Cargo.toml
@@ -94,8 +94,8 @@ witchcraft-log = "3"
 witchcraft-metrics = "1"
 zipkin = "0.4"
 
-witchcraft-server-config = { version = "3.5.0", path = "../witchcraft-server-config" }
-witchcraft-server-macros = { version = "3.5.0", path = "../witchcraft-server-macros" }
+witchcraft-server-config = { version = "3.7.0", path = "../witchcraft-server-config" }
+witchcraft-server-macros = { version = "3.7.0", path = "../witchcraft-server-macros" }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 rstack-self = { version = "0.3", features = ["dw"], default-features = false }


### PR DESCRIPTION
I autoreleased 3.6.0 without bumping the versions here

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
bump version to 3.7.0
==COMMIT_MSG==
