### PR TITLE
Support registering custom diagnostics

### DIFF
--- a/changelog/@unreleased/pr-159.v2.yml
+++ b/changelog/@unreleased/pr-159.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Expose `diagnostics` in Witchcraft so services can register their own
+    diagnostics.
+  links:
+  - https://github.com/palantir/witchcraft-rust-server/pull/159

--- a/witchcraft-server-ete/tests/ete/main.rs
+++ b/witchcraft-server-ete/tests/ete/main.rs
@@ -17,7 +17,7 @@ use http::{HeaderMap, HeaderValue};
 use hyper::body::HttpBody;
 use hyper::{body, Body, Request, StatusCode};
 use server::Server;
-use std::env;
+
 use std::pin::Pin;
 use std::str;
 use std::task::{Context, Poll};

--- a/witchcraft-server/src/debug/diagnostic_types.rs
+++ b/witchcraft-server/src/debug/diagnostic_types.rs
@@ -48,7 +48,7 @@ impl Diagnostic for DiagnosticTypesDiagnostic {
         let mut types: Vec<String> = Vec::new();
         types.push(DIAGNOSTIC_TYPES_V1.to_string());
         if let Some(registry) = self.registry.upgrade() {
-            types.push(registry.diagnostics.read().keys().cloned().collect());
+            types.extend(registry.diagnostics.lock().keys().cloned());
         }
         types.sort_unstable();
         Ok(Bytes::from(json::to_vec(&types).unwrap()).clone())

--- a/witchcraft-server/src/debug/diagnostic_types.rs
+++ b/witchcraft-server/src/debug/diagnostic_types.rs
@@ -1,3 +1,4 @@
+use std::sync::Weak;
 // Copyright 2022 Palantir Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,7 +12,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-use crate::debug::Diagnostic;
+use crate::debug::{Diagnostic, DiagnosticRegistry};
 use bytes::Bytes;
 use conjure_error::Error;
 use conjure_serde::json;
@@ -21,16 +22,12 @@ const DIAGNOSTIC_TYPES_V1: &str = "diagnostic.types.v1";
 
 /// A diagnostic which returns a list of all registered diagnostics.
 pub struct DiagnosticTypesDiagnostic {
-    types: Bytes,
+    registry: Weak<DiagnosticRegistry>
 }
 
 impl DiagnosticTypesDiagnostic {
-    pub fn new(mut types: Vec<String>) -> Self {
-        types.push(DIAGNOSTIC_TYPES_V1.to_string());
-        types.sort_unstable();
-        let types = Bytes::from(json::to_vec(&types).unwrap());
-
-        DiagnosticTypesDiagnostic { types }
+    pub fn new(registry: Weak<DiagnosticRegistry>) -> Self {
+        DiagnosticTypesDiagnostic { registry }
     }
 }
 
@@ -48,6 +45,12 @@ impl Diagnostic for DiagnosticTypesDiagnostic {
     }
 
     fn result(&self) -> Result<Bytes, Error> {
-        Ok(self.types.clone())
+        let mut types: Vec<String> = Vec::new();
+        types.push(DIAGNOSTIC_TYPES_V1.to_string());
+        if let Some(registry) = self.registry.upgrade() {
+            types.push(registry.diagnostics.read().keys().cloned().collect());
+        }
+        types.sort_unstable();
+        Ok(Bytes::from(json::to_vec(&types).unwrap()).clone())
     }
 }

--- a/witchcraft-server/src/debug/diagnostic_types.rs
+++ b/witchcraft-server/src/debug/diagnostic_types.rs
@@ -22,7 +22,7 @@ const DIAGNOSTIC_TYPES_V1: &str = "diagnostic.types.v1";
 
 /// A diagnostic which returns a list of all registered diagnostics.
 pub struct DiagnosticTypesDiagnostic {
-    registry: Weak<DiagnosticRegistry>
+    registry: Weak<DiagnosticRegistry>,
 }
 
 impl DiagnosticTypesDiagnostic {

--- a/witchcraft-server/src/debug/endpoint.rs
+++ b/witchcraft-server/src/debug/endpoint.rs
@@ -37,7 +37,7 @@ const FALSE_VALUE: HeaderValue = HeaderValue::from_static("false");
 
 struct State {
     auth: Refreshable<String, Error>,
-    diagnostics: DiagnosticRegistry,
+    diagnostics: Arc<DiagnosticRegistry>,
 }
 
 pub struct DebugEndpoints {
@@ -45,7 +45,7 @@ pub struct DebugEndpoints {
 }
 
 impl DebugEndpoints {
-    pub fn new<R>(runtime_config: &Refreshable<R, Error>, diagnostics: DiagnosticRegistry) -> Self
+    pub fn new<R>(runtime_config: &Refreshable<R, Error>, diagnostics: Arc<DiagnosticRegistry>) -> Self
     where
         R: AsRef<RuntimeConfig> + PartialEq + 'static + Sync + Send,
     {

--- a/witchcraft-server/src/debug/endpoint.rs
+++ b/witchcraft-server/src/debug/endpoint.rs
@@ -45,7 +45,10 @@ pub struct DebugEndpoints {
 }
 
 impl DebugEndpoints {
-    pub fn new<R>(runtime_config: &Refreshable<R, Error>, diagnostics: Arc<DiagnosticRegistry>) -> Self
+    pub fn new<R>(
+        runtime_config: &Refreshable<R, Error>,
+        diagnostics: Arc<DiagnosticRegistry>,
+    ) -> Self
     where
         R: AsRef<RuntimeConfig> + PartialEq + 'static + Sync + Send,
     {

--- a/witchcraft-server/src/debug/mod.rs
+++ b/witchcraft-server/src/debug/mod.rs
@@ -80,8 +80,8 @@ impl DiagnosticRegistry {
     ///
     /// Panics if another diagnostic of the same type is already registered.
     pub fn register<T>(&self, diagnostic: T)
-    where
-        T: Diagnostic + 'static + Sync + Send,
+        where
+            T: Diagnostic + 'static + Sync + Send,
     {
         self.register_inner(Arc::new(diagnostic));
     }
@@ -104,7 +104,8 @@ impl DiagnosticRegistry {
         }
     }
 
-    fn get(&self, type_: &str) -> Option<Arc<dyn Diagnostic + Sync + Send>> {
+    /// Get the diagnostic with the specified type.
+    pub fn get(&self, type_: &str) -> Option<Arc<dyn Diagnostic + Sync + Send>> {
         self.diagnostics.lock().get(type_).cloned()
     }
 }

--- a/witchcraft-server/src/debug/mod.rs
+++ b/witchcraft-server/src/debug/mod.rs
@@ -16,11 +16,11 @@ use bytes::Bytes;
 use conjure_error::Error;
 use http::HeaderValue;
 use once_cell::sync::Lazy;
+use parking_lot::RwLock;
 use regex::Regex;
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
-use std::sync::{Arc};
-use parking_lot::{RwLock};
+use std::sync::Arc;
 
 pub(crate) mod diagnostic_types;
 pub mod endpoint;
@@ -73,7 +73,6 @@ impl DiagnosticRegistry {
             TYPE_PATTERN.is_match(type_),
             "{type_} must be `lower.case.dot.delimited.v1`",
         );
-
 
         match self.diagnostics.write().entry(type_.to_string()) {
             Entry::Occupied(_) => {

--- a/witchcraft-server/src/debug/mod.rs
+++ b/witchcraft-server/src/debug/mod.rs
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
+//! Debug endpoints.
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -24,12 +24,12 @@ use parking_lot::Mutex;
 use regex::Regex;
 
 pub(crate) mod diagnostic_types;
-pub mod endpoint;
+pub(crate) mod endpoint;
 #[cfg(feature = "jemalloc")]
-pub mod heap_stats;
-pub mod metric_names;
+pub(crate) mod heap_stats;
+pub(crate) mod metric_names;
 #[cfg(target_os = "linux")]
-pub mod thread_dump;
+pub(crate) mod thread_dump;
 
 static TYPE_PATTERN: Lazy<Regex> = Lazy::new(|| Regex::new(r"([a-z0-9]+\.)+v[0-9]+").unwrap());
 

--- a/witchcraft-server/src/debug/mod.rs
+++ b/witchcraft-server/src/debug/mod.rs
@@ -64,7 +64,7 @@ impl Default for DiagnosticRegistry {
 }
 
 impl DiagnosticRegistry {
-    /// Create a new diagostnic registry
+    /// Create a new diagnostic registry
     pub fn new() -> Self {
         DiagnosticRegistry {
             diagnostics: Mutex::new(HashMap::new()),

--- a/witchcraft-server/src/debug/mod.rs
+++ b/witchcraft-server/src/debug/mod.rs
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-use crate::debug::diagnostic_types::DiagnosticTypesDiagnostic;
+
 use bytes::Bytes;
 use conjure_error::Error;
 use http::HeaderValue;
@@ -44,6 +44,12 @@ pub trait Diagnostic {
 
 pub struct DiagnosticRegistry {
     diagnostics: RwLock<HashMap<String, Arc<dyn Diagnostic + Sync + Send>>>,
+}
+
+impl Default for DiagnosticRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl DiagnosticRegistry {

--- a/witchcraft-server/src/debug/mod.rs
+++ b/witchcraft-server/src/debug/mod.rs
@@ -80,8 +80,8 @@ impl DiagnosticRegistry {
     ///
     /// Panics if another diagnostic of the same type is already registered.
     pub fn register<T>(&self, diagnostic: T)
-        where
-            T: Diagnostic + 'static + Sync + Send,
+    where
+        T: Diagnostic + 'static + Sync + Send,
     {
         self.register_inner(Arc::new(diagnostic));
     }

--- a/witchcraft-server/src/lib.rs
+++ b/witchcraft-server/src/lib.rs
@@ -278,6 +278,33 @@
 //! See the documentation of the [`conjure_runtime`] crate for the metrics reported by HTTP clients.
 #![warn(missing_docs)]
 
+use std::env;
+use std::process;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use conjure_error::Error;
+use conjure_http::server::AsyncService;
+use conjure_runtime::{Agent, ClientFactory, HostMetricsRegistry, UserAgent};
+use futures_util::{stream, Stream, StreamExt};
+use refreshable::Refreshable;
+use serde::de::DeserializeOwned;
+use tokio::runtime::Runtime;
+use tokio::signal::unix::{self, SignalKind};
+use tokio::{pin, runtime, select, time};
+use witchcraft_log::{fatal, info};
+use witchcraft_metrics::MetricRegistry;
+
+pub use body::{RequestBody, ResponseWriter};
+use config::install::InstallConfig;
+use config::runtime::RuntimeConfig;
+pub use witchcraft::Witchcraft;
+#[doc(inline)]
+pub use witchcraft_server_config as config;
+#[doc(inline)]
+pub use witchcraft_server_macros::main;
+
 use crate::debug::diagnostic_types::DiagnosticTypesDiagnostic;
 use crate::debug::endpoint::DebugEndpoints;
 #[cfg(feature = "jemalloc")]
@@ -298,30 +325,6 @@ use crate::readiness::ReadinessCheckRegistry;
 use crate::server::Listener;
 use crate::shutdown_hooks::ShutdownHooks;
 use crate::status::StatusEndpoints;
-pub use body::{RequestBody, ResponseWriter};
-use config::install::InstallConfig;
-use config::runtime::RuntimeConfig;
-use conjure_error::Error;
-use conjure_http::server::AsyncService;
-use conjure_runtime::{Agent, ClientFactory, HostMetricsRegistry, UserAgent};
-use futures_util::{stream, Stream, StreamExt};
-use refreshable::Refreshable;
-use serde::de::DeserializeOwned;
-use std::env;
-use std::process;
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-use std::sync::Arc;
-use std::time::Duration;
-use tokio::runtime::Runtime;
-use tokio::signal::unix::{self, SignalKind};
-use tokio::{pin, runtime, select, time};
-pub use witchcraft::Witchcraft;
-use witchcraft_log::{fatal, info};
-use witchcraft_metrics::MetricRegistry;
-#[doc(inline)]
-pub use witchcraft_server_config as config;
-#[doc(inline)]
-pub use witchcraft_server_macros::main;
 
 // FIXME remove in next breaking release
 #[doc(hidden)]
@@ -330,7 +333,7 @@ pub mod audit;
 pub mod blocking;
 mod body;
 mod configs;
-mod debug;
+pub mod debug;
 mod endpoint;
 pub mod extensions;
 pub mod health;

--- a/witchcraft-server/src/lib.rs
+++ b/witchcraft-server/src/lib.rs
@@ -278,6 +278,7 @@
 //! See the documentation of the [`conjure_runtime`] crate for the metrics reported by HTTP clients.
 #![warn(missing_docs)]
 
+use crate::debug::diagnostic_types::DiagnosticTypesDiagnostic;
 use crate::debug::endpoint::DebugEndpoints;
 #[cfg(feature = "jemalloc")]
 use crate::debug::heap_stats::HeapStatsDiagnostic;
@@ -321,7 +322,6 @@ use witchcraft_metrics::MetricRegistry;
 pub use witchcraft_server_config as config;
 #[doc(inline)]
 pub use witchcraft_server_macros::main;
-use crate::debug::diagnostic_types::DiagnosticTypesDiagnostic;
 
 // FIXME remove in next breaking release
 #[doc(hidden)]

--- a/witchcraft-server/src/witchcraft.rs
+++ b/witchcraft-server/src/witchcraft.rs
@@ -27,12 +27,14 @@ use std::sync::Arc;
 use tokio::runtime::Handle;
 use witchcraft_metrics::MetricRegistry;
 use witchcraft_server_config::install::InstallConfig;
+use crate::debug::DiagnosticRegistry;
 
 /// The Witchcraft server context.
 pub struct Witchcraft {
     pub(crate) metrics: Arc<MetricRegistry>,
     pub(crate) health_checks: Arc<HealthCheckRegistry>,
     pub(crate) readiness_checks: Arc<ReadinessCheckRegistry>,
+    pub(crate) diagnostics: Arc<DiagnosticRegistry>,
     pub(crate) client_factory: ClientFactory,
     pub(crate) handle: Handle,
     pub(crate) install_config: InstallConfig,
@@ -65,6 +67,9 @@ impl Witchcraft {
     pub fn client_factory(&self) -> &ClientFactory {
         &self.client_factory
     }
+
+    #[inline]
+    pub fn diagnostics(&self) -> &Arc<DiagnosticRegistry> { &&self.diagnostics}
 
     /// Returns a reference to a handle to the server's Tokio runtime.
     #[inline]

--- a/witchcraft-server/src/witchcraft.rs
+++ b/witchcraft-server/src/witchcraft.rs
@@ -68,8 +68,9 @@ impl Witchcraft {
         &self.client_factory
     }
 
+    /// Returns a reference to the server's diagnostics registry.
     #[inline]
-    pub fn diagnostics(&self) -> &Arc<DiagnosticRegistry> { &&self.diagnostics}
+    pub fn diagnostics(&self) -> &Arc<DiagnosticRegistry> { &self.diagnostics}
 
     /// Returns a reference to a handle to the server's Tokio runtime.
     #[inline]

--- a/witchcraft-server/src/witchcraft.rs
+++ b/witchcraft-server/src/witchcraft.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 use crate::blocking::conjure::ConjureBlockingEndpoint;
 use crate::blocking::pool::ThreadPool;
+use crate::debug::DiagnosticRegistry;
 use crate::endpoint::conjure::ConjureEndpoint;
 use crate::endpoint::extended_path::ExtendedPathEndpoint;
 use crate::endpoint::WitchcraftEndpoint;
@@ -27,7 +28,6 @@ use std::sync::Arc;
 use tokio::runtime::Handle;
 use witchcraft_metrics::MetricRegistry;
 use witchcraft_server_config::install::InstallConfig;
-use crate::debug::DiagnosticRegistry;
 
 /// The Witchcraft server context.
 pub struct Witchcraft {
@@ -70,7 +70,9 @@ impl Witchcraft {
 
     /// Returns a reference to the server's diagnostics registry.
     #[inline]
-    pub fn diagnostics(&self) -> &Arc<DiagnosticRegistry> { &self.diagnostics}
+    pub fn diagnostics(&self) -> &Arc<DiagnosticRegistry> {
+        &self.diagnostics
+    }
 
     /// Returns a reference to a handle to the server's Tokio runtime.
     #[inline]


### PR DESCRIPTION
## Before this PR
Diagnostics were only registered internally and it was not possible for services to add their own diagnostics. 

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Expose `diagnostics` in Witchcraft so services can register their own diagnostics. 
==COMMIT_MSG==


