### PR TITLE
improvement: allow custom config loaders

### DIFF
--- a/changelog/@unreleased/pr-160.v2.yml
+++ b/changelog/@unreleased/pr-160.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: allow custom config loaders
+  links:
+  - https://github.com/palantir/witchcraft-rust-server/pull/160


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Configs were always loaded from hard coded file paths

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
Added a new optional entry point that allows providing custom config loading functions (not necessarily even loaded from files).
==COMMIT_MSG==
allow custom config loaders
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
This can't be used with the provided `main` macro, should we add some sort of new macro or just assume anyone doing this type of configuration knows what they are doing and doesn't need it?
