### PR TITLE
Add HealthCheckRegistry::register_if_absent

### DIFF
--- a/changelog/@unreleased/pr-176.v2.yml
+++ b/changelog/@unreleased/pr-176.v2.yml
@@ -1,0 +1,6 @@
+type: feature
+feature:
+  description: Added HealthCheckRegistry::register_if_absent and downcast support
+    to HealthCheck.
+  links:
+  - https://github.com/palantir/witchcraft-rust-server/pull/176


### PR DESCRIPTION
## Before this PR
All health checks were write-only - once registered they could never be accessed again or overwritten.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Added HealthCheckRegistry::register_if_absent and downcast support to HealthCheck.
==COMMIT_MSG==

This supports similar workflows to https://github.com/palantir/witchcraft-rust-logging/pull/12, where you want to have multiple pieces of code contribute state to a health check. They can do that by all calling register_if_absent and then downcasting the returned check.

Since we pull the health check name from the check trait itself, we unfortunately can't defer creation of the check until we know it doesn't already exist like the gauge APIs do. Some check names are dynamically generated so I don't think there's a great way around that, but it shouldn't matter too much in practice.

