### PR TITLE
include more jemalloc metrics

### DIFF
--- a/changelog/@unreleased/pr-182.v2.yml
+++ b/changelog/@unreleased/pr-182.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Produce metrics reporting jemalloc active/resident memory.
+  links:
+  - https://github.com/palantir/witchcraft-rust-server/pull/182

--- a/witchcraft-server/src/lib.rs
+++ b/witchcraft-server/src/lib.rs
@@ -230,6 +230,10 @@
 //!
 //! * `process.heap` (gauge) - The total number of bytes allocated from the heap. Requires the `jemalloc` feature
 //!     (enabled by default).
+//! * `process.heap.active` (gauge) - The total number of bytes in active pages. Requires the `jemalloc` feature
+//!     (enabled by default).
+//! * `process.heap.resident` (gauge) - The total number of bytes in physically resident pages. Requires the `jemalloc` feature
+//!     (enabled by default).
 //! * `process.uptime` (gauge) - The number of microseconds that have elapsed since the server started.
 //! * `process.panics` (counter) - The number of times the server has panicked.
 //! * `process.user-time` (gauge) - The number of microseconds the process has spent running in user-space.

--- a/witchcraft-server/src/metrics/jemalloc.rs
+++ b/witchcraft-server/src/metrics/jemalloc.rs
@@ -44,7 +44,7 @@ pub fn register_metrics(metrics: &MetricRegistry) {
 
 struct Debounced<F>
 where
-    F: FnMut() -> (),
+    F: FnMut(),
 {
     function: F,
     loaded: Instant,
@@ -52,7 +52,7 @@ where
 
 impl<F> Debounced<F>
 where
-    F: FnMut() -> (),
+    F: FnMut(),
 {
     fn new(function: F) -> Debounced<F> {
         Debounced {
@@ -61,7 +61,7 @@ where
         }
     }
 
-    fn call_debounced(&mut self) -> () {
+    fn call_debounced(&mut self) {
         let now = Instant::now();
         if now - self.loaded > Duration::from_secs(1) {
             (self.function)();

--- a/witchcraft-server/src/metrics/jemalloc.rs
+++ b/witchcraft-server/src/metrics/jemalloc.rs
@@ -19,4 +19,12 @@ pub fn register_metrics(metrics: &MetricRegistry) {
         let _ = epoch::advance();
         stats::allocated::read().unwrap_or(0)
     });
+    metrics.gauge("process.heap.active", move || {
+        let _ = epoch::advance();
+        stats::active::read().unwrap_or(0)
+    });
+    metrics.gauge("process.heap.resident", move || {
+        let _ = epoch::advance();
+        stats::resident::read().unwrap_or(0)
+    });
 }

--- a/witchcraft-server/src/metrics/jemalloc.rs
+++ b/witchcraft-server/src/metrics/jemalloc.rs
@@ -1,3 +1,9 @@
+use std::{
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+use parking_lot::Mutex;
 // Copyright 2022 Palantir Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,16 +21,51 @@ use tikv_jemalloc_ctl::{epoch, stats};
 use witchcraft_metrics::MetricRegistry;
 
 pub fn register_metrics(metrics: &MetricRegistry) {
-    metrics.gauge("process.heap", move || {
+    let advance = Arc::new(Mutex::new(Debounced::new(|| {
         let _ = epoch::advance();
+    })));
+
+    let advance_for_heap = advance.clone();
+    metrics.gauge("process.heap", move || {
+        advance_for_heap.lock().call_debounced();
         stats::allocated::read().unwrap_or(0)
     });
+
+    let advance_for_active = advance.clone();
     metrics.gauge("process.heap.active", move || {
-        let _ = epoch::advance();
+        advance_for_active.lock().call_debounced();
         stats::active::read().unwrap_or(0)
     });
     metrics.gauge("process.heap.resident", move || {
-        let _ = epoch::advance();
+        advance.lock().call_debounced();
         stats::resident::read().unwrap_or(0)
     });
+}
+
+struct Debounced<F>
+where
+    F: FnMut() -> (),
+{
+    function: F,
+    loaded: Instant,
+}
+
+impl<F> Debounced<F>
+where
+    F: FnMut() -> (),
+{
+    fn new(function: F) -> Debounced<F> {
+        Debounced {
+            function,
+            loaded: Instant::now(),
+        }
+    }
+
+    fn call_debounced(&mut self) -> () {
+        let now = Instant::now();
+        if now - self.loaded > Duration::from_secs(1) {
+            (self.function)();
+            self.loaded = now;
+        }
+    }
 }


### PR DESCRIPTION
## Before this PR
When debugging memory usage, we only have a metric for the allocated memory.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Produce metrics reporting jemalloc active/resident memory.
==COMMIT_MSG==
