### PR TITLE
Enable default feature for minidump-processor

### DIFF
--- a/witchcraft-server/Cargo.toml
+++ b/witchcraft-server/Cargo.toml
@@ -57,7 +57,7 @@ itertools = "0.13"
 lazycell = "1.3"
 libc = "0.2"
 log = "0.4"
-minidump-processor = { version = "0.22", default-features = false }
+minidump-processor = "0.22"
 minidump-unwind = "0.22"
 minidump-writer = "0.10"
 minidump = "0.22"


### PR DESCRIPTION
## Before this PR
minidump-processor 0.22.2 was causing build failures (see https://github.com/rust-minidump/rust-minidump/issues/1036)

Default features were initially disabled (https://github.com/palantir/witchcraft-rust-server/pull/205 ) because it was bringing in a downstream dependency to Mio that had a CVE https://nvd.nist.gov/vuln/detail/CVE-2024-27308 (the chain is `witchcraft-server -> minidump-processor -> yaxpeax-x86 -> yaxpeax-arch -> crossterm -> mio`). We have since bumped the crossterm to 0.27.0 which should be clear of the Mio CVE.

## After this PR
Enable default features to fix builds.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

