### PR TITLE
Check minidump process state, extend connect timeout

### DIFF
--- a/witchcraft-server/src/minidump/mod.rs
+++ b/witchcraft-server/src/minidump/mod.rs
@@ -50,9 +50,8 @@ pub async fn init() -> Result<(), Error> {
         Err(e) => Error::internal_safe(e),
     })?;
 
-    mem::forget(child.stdin);
-
     // Ensure that the child's stdin says open until this process exits since that's how it detects the parent exiting.
+    mem::forget(child.stdin);
 
     let guard = CrashHandler::attach(unsafe {
         crash_handler::make_crash_event(move |context| {


### PR DESCRIPTION
Extends the overall minidump connect timeout by 2x. Adds an additional check for minidump process status when timeout occurs.