### PR TITLE
Switch aws-lc-rs crypto backend to ring

### DIFF
--- a/changelog/@unreleased/pr-221.v2.yml
+++ b/changelog/@unreleased/pr-221.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Switch aws-lc-rs crypto backend to ring
+  links:
+  - https://github.com/palantir/witchcraft-rust-server/pull/221

--- a/witchcraft-server/Cargo.toml
+++ b/witchcraft-server/Cargo.toml
@@ -88,11 +88,26 @@ subtle = "2.5"
 symbolic = { version = "12", features = ["cfi", "debuginfo"] }
 sync_wrapper = "1.0"
 tempfile = "3.10.1"
-tikv-jemalloc-ctl = { version = "0.6", features = ["stats", "use_std"], optional = true }
-tikv-jemallocator = { version = "0.6", features = ["unprefixed_malloc_on_supported_platforms", "background_threads", "profiling"], optional = true }
-tokio-rustls = "0.26"
+tikv-jemalloc-ctl = { version = "0.6", features = [
+    "stats",
+    "use_std",
+], optional = true }
+tikv-jemallocator = { version = "0.6", features = [
+    "unprefixed_malloc_on_supported_platforms",
+    "background_threads",
+    "profiling",
+], optional = true }
+tokio-rustls = { version = "0.26", default-features = false, features = [
+    "ring",
+] }
 tokio-util = "0.7"
-tokio = { version = "1.37", features = ["fs", "macros", "rt-multi-thread", "signal", "time"] }
+tokio = { version = "1.37", features = [
+    "fs",
+    "macros",
+    "rt-multi-thread",
+    "signal",
+    "time",
+] }
 tracing = { version = "0.1", features = ["log"] }
 witchcraft-log = "4"
 witchcraft-metrics = "1"

--- a/witchcraft-server/Cargo.toml
+++ b/witchcraft-server/Cargo.toml
@@ -99,6 +99,8 @@ tikv-jemallocator = { version = "0.6", features = [
 ], optional = true }
 tokio-rustls = { version = "0.26", default-features = false, features = [
     "ring",
+    "logging",
+    "tls12",
 ] }
 tokio-util = "0.7"
 tokio = { version = "1.37", features = [

--- a/witchcraft-server/src/service/tls.rs
+++ b/witchcraft-server/src/service/tls.rs
@@ -20,14 +20,14 @@ use std::io::BufReader;
 use std::path::Path;
 use std::sync::Arc;
 use tokio::io::{AsyncRead, AsyncWrite};
-use tokio_rustls::rustls::crypto::aws_lc_rs::cipher_suite::{
+use tokio_rustls::rustls::crypto::ring::cipher_suite::{
     TLS13_AES_128_GCM_SHA256, TLS13_AES_256_GCM_SHA384, TLS13_CHACHA20_POLY1305_SHA256,
     TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
     TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256, TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
     TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
 };
-use tokio_rustls::rustls::crypto::aws_lc_rs::kx_group::{SECP256R1, SECP384R1, X25519};
-use tokio_rustls::rustls::crypto::{aws_lc_rs, CryptoProvider, SupportedKxGroup};
+use tokio_rustls::rustls::crypto::ring::kx_group::{SECP256R1, SECP384R1, X25519};
+use tokio_rustls::rustls::crypto::{ring, CryptoProvider, SupportedKxGroup};
 use tokio_rustls::rustls::server::WebPkiClientVerifier;
 use tokio_rustls::rustls::version::{TLS12, TLS13};
 use tokio_rustls::rustls::{
@@ -64,7 +64,7 @@ impl TlsLayer {
         let provider = CryptoProvider {
             cipher_suites: CIPHER_SUITES.to_vec(),
             kx_groups: KX_GROUPS.to_vec(),
-            ..aws_lc_rs::default_provider()
+            ..ring::default_provider()
         };
 
         let builder = ServerConfig::builder_with_provider(Arc::new(provider))


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
We want to get rid of the aws-lc-rs crypto provider since you cannot cross compile it. This PR depends on https://github.com/palantir/conjure-rust-runtime/pull/226.

## After this PR
Switches crypto provider from aws-lc-rs to ring.

<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

