### PR TITLE
Fix minidumper in restricted ptrace environments

### DIFF
--- a/changelog/@unreleased/pr-228.v2.yml
+++ b/changelog/@unreleased/pr-228.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Fixed minidumps in restricted ptrace environments.
+  links:
+  - https://github.com/palantir/witchcraft-rust-server/pull/228

--- a/witchcraft-server-ete/tests/ete/main.rs
+++ b/witchcraft-server-ete/tests/ete/main.rs
@@ -310,7 +310,6 @@ async fn thread_dump_diagnostic() {
 
         let body = response.into_body().collect().await.unwrap().to_bytes();
         let body = str::from_utf8(&body).unwrap();
-        println!("{body}");
         // We know there should be one thread in the thread dump diagnostic code, so this is an
         // easy way to infer if we were able to symbolicate the stack traces.
         assert!(body.contains("ThreadDumpDiagnostic"));

--- a/witchcraft-server-ete/tests/ete/main.rs
+++ b/witchcraft-server-ete/tests/ete/main.rs
@@ -287,11 +287,6 @@ async fn diagnostic_types_diagnostic() {
 #[tokio::test]
 #[cfg(target_os = "linux")]
 async fn thread_dump_diagnostic() {
-    // FIXME https://github.com/palantir/witchcraft-rust-server/issues/74
-    if std::env::var_os("CI").is_some() {
-        return;
-    }
-
     Server::with(|server| async move {
         let request = Request::builder()
             .uri("/witchcraft-ete/debug/diagnostic/rust.thread.dump.v1")
@@ -315,6 +310,7 @@ async fn thread_dump_diagnostic() {
 
         let body = response.into_body().collect().await.unwrap().to_bytes();
         let body = str::from_utf8(&body).unwrap();
+        println!("{body}");
         // We know there should be one thread in the thread dump diagnostic code, so this is an
         // easy way to infer if we were able to symbolicate the stack traces.
         assert!(body.contains("ThreadDumpDiagnostic"));

--- a/witchcraft-server/src/health/api/check_type.rs
+++ b/witchcraft-server/src/health/api/check_type.rs
@@ -1,5 +1,16 @@
-use conjure_object::serde::{ser, de};
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[derive(
+    Debug,
+    Clone,
+    conjure_object::serde::Deserialize,
+    conjure_object::serde::Serialize,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Default
+)]
+#[serde(crate = "conjure_object::serde", transparent)]
 pub struct CheckType(pub String);
 impl std::fmt::Display for CheckType {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -35,21 +46,5 @@ impl std::ops::DerefMut for CheckType {
     #[inline]
     fn deref_mut(&mut self) -> &mut String {
         &mut self.0
-    }
-}
-impl ser::Serialize for CheckType {
-    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
-    where
-        S: ser::Serializer,
-    {
-        self.0.serialize(s)
-    }
-}
-impl<'de> de::Deserialize<'de> for CheckType {
-    fn deserialize<D>(d: D) -> Result<CheckType, D::Error>
-    where
-        D: de::Deserializer<'de>,
-    {
-        de::Deserialize::deserialize(d).map(CheckType)
     }
 }

--- a/witchcraft-server/src/health/api/health_check_result.rs
+++ b/witchcraft-server/src/health/api/health_check_result.rs
@@ -1,14 +1,25 @@
-use conjure_object::serde::{ser, de};
-use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use std::fmt;
 ///Metadata describing the status of a service.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+    Debug,
+    Clone,
+    conjure_object::serde::Serialize,
+    conjure_object::serde::Deserialize,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash
+)]
+#[serde(crate = "conjure_object::serde")]
 #[conjure_object::private::staged_builder::staged_builder]
 #[builder(crate = conjure_object::private::staged_builder, update, inline)]
 pub struct HealthCheckResult {
+    #[serde(rename = "type")]
     type_: super::CheckType,
+    #[serde(rename = "state")]
     state: super::HealthState,
     #[builder(default, into)]
+    #[serde(rename = "message", skip_serializing_if = "Option::is_none", default)]
     message: Option<String>,
     #[builder(
         default,
@@ -24,6 +35,11 @@ pub struct HealthCheckResult {
                 )
             )
         )
+    )]
+    #[serde(
+        rename = "params",
+        skip_serializing_if = "std::collections::BTreeMap::is_empty",
+        default
     )]
     params: std::collections::BTreeMap<String, conjure_object::Any>,
 }
@@ -52,131 +68,5 @@ impl HealthCheckResult {
     #[inline]
     pub fn params(&self) -> &std::collections::BTreeMap<String, conjure_object::Any> {
         &self.params
-    }
-}
-impl ser::Serialize for HealthCheckResult {
-    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
-    where
-        S: ser::Serializer,
-    {
-        let mut size = 2usize;
-        let skip_message = self.message.is_none();
-        if !skip_message {
-            size += 1;
-        }
-        let skip_params = self.params.is_empty();
-        if !skip_params {
-            size += 1;
-        }
-        let mut s = s.serialize_struct("HealthCheckResult", size)?;
-        s.serialize_field("type", &self.type_)?;
-        s.serialize_field("state", &self.state)?;
-        if skip_message {
-            s.skip_field("message")?;
-        } else {
-            s.serialize_field("message", &self.message)?;
-        }
-        if skip_params {
-            s.skip_field("params")?;
-        } else {
-            s.serialize_field("params", &self.params)?;
-        }
-        s.end()
-    }
-}
-impl<'de> de::Deserialize<'de> for HealthCheckResult {
-    fn deserialize<D>(d: D) -> Result<HealthCheckResult, D::Error>
-    where
-        D: de::Deserializer<'de>,
-    {
-        d.deserialize_struct(
-            "HealthCheckResult",
-            &["type", "state", "message", "params"],
-            Visitor_,
-        )
-    }
-}
-struct Visitor_;
-impl<'de> de::Visitor<'de> for Visitor_ {
-    type Value = HealthCheckResult;
-    fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.write_str("map")
-    }
-    fn visit_map<A>(self, mut map_: A) -> Result<HealthCheckResult, A::Error>
-    where
-        A: de::MapAccess<'de>,
-    {
-        let mut type_ = None;
-        let mut state = None;
-        let mut message = None;
-        let mut params = None;
-        while let Some(field_) = map_.next_key()? {
-            match field_ {
-                Field_::Type => type_ = Some(map_.next_value()?),
-                Field_::State => state = Some(map_.next_value()?),
-                Field_::Message => message = Some(map_.next_value()?),
-                Field_::Params => params = Some(map_.next_value()?),
-                Field_::Unknown_ => {
-                    map_.next_value::<de::IgnoredAny>()?;
-                }
-            }
-        }
-        let type_ = match type_ {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("type")),
-        };
-        let state = match state {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("state")),
-        };
-        let message = match message {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let params = match params {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        Ok(HealthCheckResult {
-            type_,
-            state,
-            message,
-            params,
-        })
-    }
-}
-enum Field_ {
-    Type,
-    State,
-    Message,
-    Params,
-    Unknown_,
-}
-impl<'de> de::Deserialize<'de> for Field_ {
-    fn deserialize<D>(d: D) -> Result<Field_, D::Error>
-    where
-        D: de::Deserializer<'de>,
-    {
-        d.deserialize_str(FieldVisitor_)
-    }
-}
-struct FieldVisitor_;
-impl<'de> de::Visitor<'de> for FieldVisitor_ {
-    type Value = Field_;
-    fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.write_str("string")
-    }
-    fn visit_str<E>(self, value: &str) -> Result<Field_, E>
-    where
-        E: de::Error,
-    {
-        let v = match value {
-            "type" => Field_::Type,
-            "state" => Field_::State,
-            "message" => Field_::Message,
-            "params" => Field_::Params,
-            _ => Field_::Unknown_,
-        };
-        Ok(v)
     }
 }

--- a/witchcraft-server/src/health/api/health_state.rs
+++ b/witchcraft-server/src/health/api/health_state.rs
@@ -1,21 +1,39 @@
-use conjure_object::serde::{ser, de};
+#![allow(deprecated)]
 use std::fmt;
 use std::str;
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    conjure_object::serde::Deserialize,
+    conjure_object::serde::Serialize,
+)]
+#[serde(crate = "conjure_object::serde")]
 pub enum HealthState {
     ///The service node is fully operational with no issues.
+    #[serde(rename = "HEALTHY")]
     Healthy,
     ///The service node is fully operational with no issues; however, it is requesting to defer shutdown or restart. A deferring node should not accept "new" jobs but should allow polling of existing jobs.
+    #[serde(rename = "DEFERRING")]
     Deferring,
     ///The service node is no longer serving requests and is ready to be shut down. Nodes in a deferring state are expected to change to a suspended state once they have completed any pending work. A suspended node must also indicate in its readiness probe that it should not receive incoming requests.
+    #[serde(rename = "SUSPENDED")]
     Suspended,
     ///The service node is operating in a degraded state, but is capable of automatically recovering. If any of the nodes in the service were to be restarted, it may result in correctness or consistency issues with the service. Ex: When a cassandra node decides it is not up-to-date and needs to repair, the node is operating in a degraded state. Restarting the node prior to the repair being complete might result in the service being unable to correctly respond to requests.
+    #[serde(rename = "REPAIRING")]
     Repairing,
     ///The service node is in a state that is trending towards an error. If no corrective action is taken, the health is expected to become an error.
+    #[serde(rename = "WARNING")]
     Warning,
     ///The service node is operationally unhealthy.
+    #[serde(rename = "ERROR")]
     Error,
     ///The service node has entered an unrecoverable state. All nodes of the service should be stopped and no automated attempt to restart the node should be made. Ex: a service fails to migrate to a new schema and is left in an unrecoverable state.
+    #[serde(rename = "TERMINAL")]
     Terminal,
 }
 impl HealthState {
@@ -66,52 +84,5 @@ impl conjure_object::FromPlain for HealthState {
         v: &str,
     ) -> Result<HealthState, conjure_object::plain::ParseEnumError> {
         v.parse()
-    }
-}
-impl ser::Serialize for HealthState {
-    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
-    where
-        S: ser::Serializer,
-    {
-        s.serialize_str(self.as_str())
-    }
-}
-impl<'de> de::Deserialize<'de> for HealthState {
-    fn deserialize<D>(d: D) -> Result<HealthState, D::Error>
-    where
-        D: de::Deserializer<'de>,
-    {
-        d.deserialize_str(Visitor_)
-    }
-}
-struct Visitor_;
-impl<'de> de::Visitor<'de> for Visitor_ {
-    type Value = HealthState;
-    fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.write_str("a string")
-    }
-    fn visit_str<E>(self, v: &str) -> Result<HealthState, E>
-    where
-        E: de::Error,
-    {
-        match v.parse() {
-            Ok(e) => Ok(e),
-            Err(_) => {
-                Err(
-                    de::Error::unknown_variant(
-                        v,
-                        &[
-                            "HEALTHY",
-                            "DEFERRING",
-                            "SUSPENDED",
-                            "REPAIRING",
-                            "WARNING",
-                            "ERROR",
-                            "TERMINAL",
-                        ],
-                    ),
-                )
-            }
-        }
     }
 }

--- a/witchcraft-server/src/health/api/health_status.rs
+++ b/witchcraft-server/src/health/api/health_status.rs
@@ -1,13 +1,26 @@
-use conjure_object::serde::{ser, de};
-use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use std::fmt;
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+    Debug,
+    Clone,
+    conjure_object::serde::Serialize,
+    conjure_object::serde::Deserialize,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash
+)]
+#[serde(crate = "conjure_object::serde")]
 #[conjure_object::private::staged_builder::staged_builder]
 #[builder(crate = conjure_object::private::staged_builder, update, inline)]
 pub struct HealthStatus {
     #[builder(
         default,
         map(key(type = super::CheckType), value(type = super::HealthCheckResult))
+    )]
+    #[serde(
+        rename = "checks",
+        skip_serializing_if = "std::collections::BTreeMap::is_empty",
+        default
     )]
     checks: std::collections::BTreeMap<super::CheckType, super::HealthCheckResult>,
 }
@@ -22,87 +35,5 @@ impl HealthStatus {
         &self,
     ) -> &std::collections::BTreeMap<super::CheckType, super::HealthCheckResult> {
         &self.checks
-    }
-}
-impl ser::Serialize for HealthStatus {
-    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
-    where
-        S: ser::Serializer,
-    {
-        let mut size = 0usize;
-        let skip_checks = self.checks.is_empty();
-        if !skip_checks {
-            size += 1;
-        }
-        let mut s = s.serialize_struct("HealthStatus", size)?;
-        if skip_checks {
-            s.skip_field("checks")?;
-        } else {
-            s.serialize_field("checks", &self.checks)?;
-        }
-        s.end()
-    }
-}
-impl<'de> de::Deserialize<'de> for HealthStatus {
-    fn deserialize<D>(d: D) -> Result<HealthStatus, D::Error>
-    where
-        D: de::Deserializer<'de>,
-    {
-        d.deserialize_struct("HealthStatus", &["checks"], Visitor_)
-    }
-}
-struct Visitor_;
-impl<'de> de::Visitor<'de> for Visitor_ {
-    type Value = HealthStatus;
-    fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.write_str("map")
-    }
-    fn visit_map<A>(self, mut map_: A) -> Result<HealthStatus, A::Error>
-    where
-        A: de::MapAccess<'de>,
-    {
-        let mut checks = None;
-        while let Some(field_) = map_.next_key()? {
-            match field_ {
-                Field_::Checks => checks = Some(map_.next_value()?),
-                Field_::Unknown_ => {
-                    map_.next_value::<de::IgnoredAny>()?;
-                }
-            }
-        }
-        let checks = match checks {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        Ok(HealthStatus { checks })
-    }
-}
-enum Field_ {
-    Checks,
-    Unknown_,
-}
-impl<'de> de::Deserialize<'de> for Field_ {
-    fn deserialize<D>(d: D) -> Result<Field_, D::Error>
-    where
-        D: de::Deserializer<'de>,
-    {
-        d.deserialize_str(FieldVisitor_)
-    }
-}
-struct FieldVisitor_;
-impl<'de> de::Visitor<'de> for FieldVisitor_ {
-    type Value = Field_;
-    fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.write_str("string")
-    }
-    fn visit_str<E>(self, value: &str) -> Result<Field_, E>
-    where
-        E: de::Error,
-    {
-        let v = match value {
-            "checks" => Field_::Checks,
-            _ => Field_::Unknown_,
-        };
-        Ok(v)
     }
 }

--- a/witchcraft-server/src/logging/api/annotation.rs
+++ b/witchcraft-server/src/logging/api/annotation.rs
@@ -1,15 +1,26 @@
-use conjure_object::serde::{ser, de};
-use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use std::fmt;
 ///A Zipkin-compatible Annotation object.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+    Debug,
+    Clone,
+    conjure_object::serde::Serialize,
+    conjure_object::serde::Deserialize,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash
+)]
+#[serde(crate = "conjure_object::serde")]
 #[conjure_object::private::staged_builder::staged_builder]
 #[builder(crate = conjure_object::private::staged_builder, update, inline)]
 pub struct Annotation {
+    #[serde(rename = "timestamp")]
     timestamp: conjure_object::SafeLong,
     #[builder(into)]
+    #[serde(rename = "value")]
     value: String,
     #[builder(custom(type = super::Endpoint, convert = Box::new))]
+    #[serde(rename = "endpoint")]
     endpoint: Box<super::Endpoint>,
 }
 impl Annotation {
@@ -35,101 +46,5 @@ impl Annotation {
     #[inline]
     pub fn endpoint(&self) -> &super::Endpoint {
         &*self.endpoint
-    }
-}
-impl ser::Serialize for Annotation {
-    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
-    where
-        S: ser::Serializer,
-    {
-        let size = 3usize;
-        let mut s = s.serialize_struct("Annotation", size)?;
-        s.serialize_field("timestamp", &self.timestamp)?;
-        s.serialize_field("value", &self.value)?;
-        s.serialize_field("endpoint", &self.endpoint)?;
-        s.end()
-    }
-}
-impl<'de> de::Deserialize<'de> for Annotation {
-    fn deserialize<D>(d: D) -> Result<Annotation, D::Error>
-    where
-        D: de::Deserializer<'de>,
-    {
-        d.deserialize_struct("Annotation", &["timestamp", "value", "endpoint"], Visitor_)
-    }
-}
-struct Visitor_;
-impl<'de> de::Visitor<'de> for Visitor_ {
-    type Value = Annotation;
-    fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.write_str("map")
-    }
-    fn visit_map<A>(self, mut map_: A) -> Result<Annotation, A::Error>
-    where
-        A: de::MapAccess<'de>,
-    {
-        let mut timestamp = None;
-        let mut value = None;
-        let mut endpoint = None;
-        while let Some(field_) = map_.next_key()? {
-            match field_ {
-                Field_::Timestamp => timestamp = Some(map_.next_value()?),
-                Field_::Value => value = Some(map_.next_value()?),
-                Field_::Endpoint => endpoint = Some(map_.next_value()?),
-                Field_::Unknown_ => {
-                    map_.next_value::<de::IgnoredAny>()?;
-                }
-            }
-        }
-        let timestamp = match timestamp {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("timestamp")),
-        };
-        let value = match value {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("value")),
-        };
-        let endpoint = match endpoint {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("endpoint")),
-        };
-        Ok(Annotation {
-            timestamp,
-            value,
-            endpoint,
-        })
-    }
-}
-enum Field_ {
-    Timestamp,
-    Value,
-    Endpoint,
-    Unknown_,
-}
-impl<'de> de::Deserialize<'de> for Field_ {
-    fn deserialize<D>(d: D) -> Result<Field_, D::Error>
-    where
-        D: de::Deserializer<'de>,
-    {
-        d.deserialize_str(FieldVisitor_)
-    }
-}
-struct FieldVisitor_;
-impl<'de> de::Visitor<'de> for FieldVisitor_ {
-    type Value = Field_;
-    fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.write_str("string")
-    }
-    fn visit_str<E>(self, value: &str) -> Result<Field_, E>
-    where
-        E: de::Error,
-    {
-        let v = match value {
-            "timestamp" => Field_::Timestamp,
-            "value" => Field_::Value,
-            "endpoint" => Field_::Endpoint,
-            _ => Field_::Unknown_,
-        };
-        Ok(v)
     }
 }

--- a/witchcraft-server/src/logging/api/audit_log_v2.rs
+++ b/witchcraft-server/src/logging/api/audit_log_v2.rs
@@ -1,30 +1,49 @@
-use conjure_object::serde::{ser, de};
-use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use std::fmt;
 ///Definition of the audit.2 format.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+    Debug,
+    Clone,
+    conjure_object::serde::Serialize,
+    conjure_object::serde::Deserialize,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash
+)]
+#[serde(crate = "conjure_object::serde")]
 #[conjure_object::private::staged_builder::staged_builder]
 #[builder(crate = conjure_object::private::staged_builder, update, inline)]
 pub struct AuditLogV2 {
     #[builder(into)]
+    #[serde(rename = "type")]
     type_: String,
+    #[serde(rename = "time")]
     time: conjure_object::DateTime<conjure_object::Utc>,
     #[builder(default, into)]
+    #[serde(rename = "uid", skip_serializing_if = "Option::is_none", default)]
     uid: Option<super::UserId>,
     #[builder(default, into)]
+    #[serde(rename = "sid", skip_serializing_if = "Option::is_none", default)]
     sid: Option<super::SessionId>,
     #[builder(default, into)]
+    #[serde(rename = "tokenId", skip_serializing_if = "Option::is_none", default)]
     token_id: Option<super::TokenId>,
     #[builder(default, into)]
+    #[serde(rename = "orgId", skip_serializing_if = "Option::is_none", default)]
     org_id: Option<super::OrganizationId>,
     #[builder(default, into)]
+    #[serde(rename = "traceId", skip_serializing_if = "Option::is_none", default)]
     trace_id: Option<super::TraceId>,
     #[builder(default, list(item(type = super::UserId)))]
+    #[serde(rename = "otherUids", skip_serializing_if = "Vec::is_empty", default)]
     other_uids: Vec<super::UserId>,
     #[builder(default, into)]
+    #[serde(rename = "origin", skip_serializing_if = "Option::is_none", default)]
     origin: Option<String>,
     #[builder(into)]
+    #[serde(rename = "name")]
     name: String,
+    #[serde(rename = "result")]
     result: super::AuditResult,
     #[builder(
         default,
@@ -41,6 +60,11 @@ pub struct AuditLogV2 {
             )
         )
     )]
+    #[serde(
+        rename = "requestParams",
+        skip_serializing_if = "std::collections::BTreeMap::is_empty",
+        default
+    )]
     request_params: std::collections::BTreeMap<String, conjure_object::Any>,
     #[builder(
         default,
@@ -56,6 +80,11 @@ pub struct AuditLogV2 {
                 )
             )
         )
+    )]
+    #[serde(
+        rename = "resultParams",
+        skip_serializing_if = "std::collections::BTreeMap::is_empty",
+        default
     )]
     result_params: std::collections::BTreeMap<String, conjure_object::Any>,
 }
@@ -128,291 +157,5 @@ impl AuditLogV2 {
         &self,
     ) -> &std::collections::BTreeMap<String, conjure_object::Any> {
         &self.result_params
-    }
-}
-impl ser::Serialize for AuditLogV2 {
-    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
-    where
-        S: ser::Serializer,
-    {
-        let mut size = 4usize;
-        let skip_uid = self.uid.is_none();
-        if !skip_uid {
-            size += 1;
-        }
-        let skip_sid = self.sid.is_none();
-        if !skip_sid {
-            size += 1;
-        }
-        let skip_token_id = self.token_id.is_none();
-        if !skip_token_id {
-            size += 1;
-        }
-        let skip_org_id = self.org_id.is_none();
-        if !skip_org_id {
-            size += 1;
-        }
-        let skip_trace_id = self.trace_id.is_none();
-        if !skip_trace_id {
-            size += 1;
-        }
-        let skip_other_uids = self.other_uids.is_empty();
-        if !skip_other_uids {
-            size += 1;
-        }
-        let skip_origin = self.origin.is_none();
-        if !skip_origin {
-            size += 1;
-        }
-        let skip_request_params = self.request_params.is_empty();
-        if !skip_request_params {
-            size += 1;
-        }
-        let skip_result_params = self.result_params.is_empty();
-        if !skip_result_params {
-            size += 1;
-        }
-        let mut s = s.serialize_struct("AuditLogV2", size)?;
-        s.serialize_field("type", &self.type_)?;
-        s.serialize_field("time", &self.time)?;
-        if skip_uid {
-            s.skip_field("uid")?;
-        } else {
-            s.serialize_field("uid", &self.uid)?;
-        }
-        if skip_sid {
-            s.skip_field("sid")?;
-        } else {
-            s.serialize_field("sid", &self.sid)?;
-        }
-        if skip_token_id {
-            s.skip_field("tokenId")?;
-        } else {
-            s.serialize_field("tokenId", &self.token_id)?;
-        }
-        if skip_org_id {
-            s.skip_field("orgId")?;
-        } else {
-            s.serialize_field("orgId", &self.org_id)?;
-        }
-        if skip_trace_id {
-            s.skip_field("traceId")?;
-        } else {
-            s.serialize_field("traceId", &self.trace_id)?;
-        }
-        if skip_other_uids {
-            s.skip_field("otherUids")?;
-        } else {
-            s.serialize_field("otherUids", &self.other_uids)?;
-        }
-        if skip_origin {
-            s.skip_field("origin")?;
-        } else {
-            s.serialize_field("origin", &self.origin)?;
-        }
-        s.serialize_field("name", &self.name)?;
-        s.serialize_field("result", &self.result)?;
-        if skip_request_params {
-            s.skip_field("requestParams")?;
-        } else {
-            s.serialize_field("requestParams", &self.request_params)?;
-        }
-        if skip_result_params {
-            s.skip_field("resultParams")?;
-        } else {
-            s.serialize_field("resultParams", &self.result_params)?;
-        }
-        s.end()
-    }
-}
-impl<'de> de::Deserialize<'de> for AuditLogV2 {
-    fn deserialize<D>(d: D) -> Result<AuditLogV2, D::Error>
-    where
-        D: de::Deserializer<'de>,
-    {
-        d.deserialize_struct(
-            "AuditLogV2",
-            &[
-                "type",
-                "time",
-                "uid",
-                "sid",
-                "tokenId",
-                "orgId",
-                "traceId",
-                "otherUids",
-                "origin",
-                "name",
-                "result",
-                "requestParams",
-                "resultParams",
-            ],
-            Visitor_,
-        )
-    }
-}
-struct Visitor_;
-impl<'de> de::Visitor<'de> for Visitor_ {
-    type Value = AuditLogV2;
-    fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.write_str("map")
-    }
-    fn visit_map<A>(self, mut map_: A) -> Result<AuditLogV2, A::Error>
-    where
-        A: de::MapAccess<'de>,
-    {
-        let mut type_ = None;
-        let mut time = None;
-        let mut uid = None;
-        let mut sid = None;
-        let mut token_id = None;
-        let mut org_id = None;
-        let mut trace_id = None;
-        let mut other_uids = None;
-        let mut origin = None;
-        let mut name = None;
-        let mut result = None;
-        let mut request_params = None;
-        let mut result_params = None;
-        while let Some(field_) = map_.next_key()? {
-            match field_ {
-                Field_::Type => type_ = Some(map_.next_value()?),
-                Field_::Time => time = Some(map_.next_value()?),
-                Field_::Uid => uid = Some(map_.next_value()?),
-                Field_::Sid => sid = Some(map_.next_value()?),
-                Field_::TokenId => token_id = Some(map_.next_value()?),
-                Field_::OrgId => org_id = Some(map_.next_value()?),
-                Field_::TraceId => trace_id = Some(map_.next_value()?),
-                Field_::OtherUids => other_uids = Some(map_.next_value()?),
-                Field_::Origin => origin = Some(map_.next_value()?),
-                Field_::Name => name = Some(map_.next_value()?),
-                Field_::Result => result = Some(map_.next_value()?),
-                Field_::RequestParams => request_params = Some(map_.next_value()?),
-                Field_::ResultParams => result_params = Some(map_.next_value()?),
-                Field_::Unknown_ => {
-                    map_.next_value::<de::IgnoredAny>()?;
-                }
-            }
-        }
-        let type_ = match type_ {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("type")),
-        };
-        let time = match time {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("time")),
-        };
-        let uid = match uid {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let sid = match sid {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let token_id = match token_id {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let org_id = match org_id {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let trace_id = match trace_id {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let other_uids = match other_uids {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let origin = match origin {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let name = match name {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("name")),
-        };
-        let result = match result {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("result")),
-        };
-        let request_params = match request_params {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let result_params = match result_params {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        Ok(AuditLogV2 {
-            type_,
-            time,
-            uid,
-            sid,
-            token_id,
-            org_id,
-            trace_id,
-            other_uids,
-            origin,
-            name,
-            result,
-            request_params,
-            result_params,
-        })
-    }
-}
-enum Field_ {
-    Type,
-    Time,
-    Uid,
-    Sid,
-    TokenId,
-    OrgId,
-    TraceId,
-    OtherUids,
-    Origin,
-    Name,
-    Result,
-    RequestParams,
-    ResultParams,
-    Unknown_,
-}
-impl<'de> de::Deserialize<'de> for Field_ {
-    fn deserialize<D>(d: D) -> Result<Field_, D::Error>
-    where
-        D: de::Deserializer<'de>,
-    {
-        d.deserialize_str(FieldVisitor_)
-    }
-}
-struct FieldVisitor_;
-impl<'de> de::Visitor<'de> for FieldVisitor_ {
-    type Value = Field_;
-    fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.write_str("string")
-    }
-    fn visit_str<E>(self, value: &str) -> Result<Field_, E>
-    where
-        E: de::Error,
-    {
-        let v = match value {
-            "type" => Field_::Type,
-            "time" => Field_::Time,
-            "uid" => Field_::Uid,
-            "sid" => Field_::Sid,
-            "tokenId" => Field_::TokenId,
-            "orgId" => Field_::OrgId,
-            "traceId" => Field_::TraceId,
-            "otherUids" => Field_::OtherUids,
-            "origin" => Field_::Origin,
-            "name" => Field_::Name,
-            "result" => Field_::Result,
-            "requestParams" => Field_::RequestParams,
-            "resultParams" => Field_::ResultParams,
-            _ => Field_::Unknown_,
-        };
-        Ok(v)
     }
 }

--- a/witchcraft-server/src/logging/api/audit_log_v3.rs
+++ b/witchcraft-server/src/logging/api/audit_log_v3.rs
@@ -1,33 +1,54 @@
-use conjure_object::serde::{ser, de};
-use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use std::fmt;
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+    Debug,
+    Clone,
+    conjure_object::serde::Serialize,
+    conjure_object::serde::Deserialize,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash
+)]
+#[serde(crate = "conjure_object::serde")]
 #[conjure_object::private::staged_builder::staged_builder]
 #[builder(crate = conjure_object::private::staged_builder, update, inline)]
 pub struct AuditLogV3 {
     #[builder(into)]
+    #[serde(rename = "type")]
     type_: String,
     #[builder(into)]
+    #[serde(rename = "deployment")]
     deployment: String,
     #[builder(into)]
+    #[serde(rename = "host")]
     host: String,
     #[builder(into)]
+    #[serde(rename = "product")]
     product: String,
     #[builder(into)]
+    #[serde(rename = "productVersion")]
     product_version: String,
     #[builder(default, into)]
+    #[serde(rename = "stack", skip_serializing_if = "Option::is_none", default)]
     stack: Option<String>,
     #[builder(default, into)]
+    #[serde(rename = "service", skip_serializing_if = "Option::is_none", default)]
     service: Option<String>,
     #[builder(default, into)]
+    #[serde(rename = "environment", skip_serializing_if = "Option::is_none", default)]
     environment: Option<String>,
+    #[serde(rename = "producerType")]
     producer_type: super::AuditProducer,
     #[builder(default, list(item(type = super::Organization)))]
+    #[serde(rename = "organizations", skip_serializing_if = "Vec::is_empty", default)]
     organizations: Vec<super::Organization>,
+    #[serde(rename = "eventId")]
     event_id: conjure_object::Uuid,
     #[builder(default, into)]
+    #[serde(rename = "userAgent", skip_serializing_if = "Option::is_none", default)]
     user_agent: Option<String>,
     #[builder(default, list(item(type = String, into)))]
+    #[serde(rename = "categories", skip_serializing_if = "Vec::is_empty", default)]
     categories: Vec<String>,
     #[builder(
         default,
@@ -43,16 +64,25 @@ pub struct AuditLogV3 {
             )
         )
     )]
+    #[serde(rename = "entities", skip_serializing_if = "Vec::is_empty", default)]
     entities: Vec<conjure_object::Any>,
     #[builder(default, list(item(type = super::ContextualizedUser)))]
+    #[serde(rename = "users", skip_serializing_if = "Vec::is_empty", default)]
     users: Vec<super::ContextualizedUser>,
     #[builder(default, list(item(type = String, into)))]
+    #[serde(rename = "origins", skip_serializing_if = "Vec::is_empty", default)]
     origins: Vec<String>,
     #[builder(default, into)]
+    #[serde(rename = "sourceOrigin", skip_serializing_if = "Option::is_none", default)]
     source_origin: Option<String>,
     #[builder(
         default,
         map(key(type = String, into), value(type = super::SensitivityTaggedValue))
+    )]
+    #[serde(
+        rename = "requestParams",
+        skip_serializing_if = "std::collections::BTreeMap::is_empty",
+        default
     )]
     request_params: std::collections::BTreeMap<String, super::SensitivityTaggedValue>,
     #[builder(
@@ -70,10 +100,20 @@ pub struct AuditLogV3 {
             )
         )
     )]
+    #[serde(
+        rename = "requestFields",
+        skip_serializing_if = "std::collections::BTreeMap::is_empty",
+        default
+    )]
     request_fields: std::collections::BTreeMap<String, conjure_object::Any>,
     #[builder(
         default,
         map(key(type = String, into), value(type = super::SensitivityTaggedValue))
+    )]
+    #[serde(
+        rename = "resultParams",
+        skip_serializing_if = "std::collections::BTreeMap::is_empty",
+        default
     )]
     result_params: std::collections::BTreeMap<String, super::SensitivityTaggedValue>,
     #[builder(
@@ -91,22 +131,36 @@ pub struct AuditLogV3 {
             )
         )
     )]
+    #[serde(
+        rename = "resultFields",
+        skip_serializing_if = "std::collections::BTreeMap::is_empty",
+        default
+    )]
     result_fields: std::collections::BTreeMap<String, conjure_object::Any>,
+    #[serde(rename = "time")]
     time: conjure_object::DateTime<conjure_object::Utc>,
     #[builder(default, into)]
+    #[serde(rename = "uid", skip_serializing_if = "Option::is_none", default)]
     uid: Option<super::UserId>,
     #[builder(default, into)]
+    #[serde(rename = "sid", skip_serializing_if = "Option::is_none", default)]
     sid: Option<super::SessionId>,
     #[builder(default, into)]
+    #[serde(rename = "tokenId", skip_serializing_if = "Option::is_none", default)]
     token_id: Option<super::TokenId>,
     #[builder(default, into)]
+    #[serde(rename = "orgId", skip_serializing_if = "Option::is_none", default)]
     org_id: Option<super::OrganizationId>,
     #[builder(default, into)]
+    #[serde(rename = "traceId", skip_serializing_if = "Option::is_none", default)]
     trace_id: Option<super::TraceId>,
     #[builder(default, into)]
+    #[serde(rename = "origin", skip_serializing_if = "Option::is_none", default)]
     origin: Option<String>,
     #[builder(into)]
+    #[serde(rename = "name")]
     name: String,
+    #[serde(rename = "result")]
     result: super::AuditResult,
 }
 impl AuditLogV3 {
@@ -296,566 +350,5 @@ impl AuditLogV3 {
     #[inline]
     pub fn result(&self) -> &super::AuditResult {
         &self.result
-    }
-}
-impl ser::Serialize for AuditLogV3 {
-    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
-    where
-        S: ser::Serializer,
-    {
-        let mut size = 10usize;
-        let skip_stack = self.stack.is_none();
-        if !skip_stack {
-            size += 1;
-        }
-        let skip_service = self.service.is_none();
-        if !skip_service {
-            size += 1;
-        }
-        let skip_environment = self.environment.is_none();
-        if !skip_environment {
-            size += 1;
-        }
-        let skip_organizations = self.organizations.is_empty();
-        if !skip_organizations {
-            size += 1;
-        }
-        let skip_user_agent = self.user_agent.is_none();
-        if !skip_user_agent {
-            size += 1;
-        }
-        let skip_categories = self.categories.is_empty();
-        if !skip_categories {
-            size += 1;
-        }
-        let skip_entities = self.entities.is_empty();
-        if !skip_entities {
-            size += 1;
-        }
-        let skip_users = self.users.is_empty();
-        if !skip_users {
-            size += 1;
-        }
-        let skip_origins = self.origins.is_empty();
-        if !skip_origins {
-            size += 1;
-        }
-        let skip_source_origin = self.source_origin.is_none();
-        if !skip_source_origin {
-            size += 1;
-        }
-        let skip_request_params = self.request_params.is_empty();
-        if !skip_request_params {
-            size += 1;
-        }
-        let skip_request_fields = self.request_fields.is_empty();
-        if !skip_request_fields {
-            size += 1;
-        }
-        let skip_result_params = self.result_params.is_empty();
-        if !skip_result_params {
-            size += 1;
-        }
-        let skip_result_fields = self.result_fields.is_empty();
-        if !skip_result_fields {
-            size += 1;
-        }
-        let skip_uid = self.uid.is_none();
-        if !skip_uid {
-            size += 1;
-        }
-        let skip_sid = self.sid.is_none();
-        if !skip_sid {
-            size += 1;
-        }
-        let skip_token_id = self.token_id.is_none();
-        if !skip_token_id {
-            size += 1;
-        }
-        let skip_org_id = self.org_id.is_none();
-        if !skip_org_id {
-            size += 1;
-        }
-        let skip_trace_id = self.trace_id.is_none();
-        if !skip_trace_id {
-            size += 1;
-        }
-        let skip_origin = self.origin.is_none();
-        if !skip_origin {
-            size += 1;
-        }
-        let mut s = s.serialize_struct("AuditLogV3", size)?;
-        s.serialize_field("type", &self.type_)?;
-        s.serialize_field("deployment", &self.deployment)?;
-        s.serialize_field("host", &self.host)?;
-        s.serialize_field("product", &self.product)?;
-        s.serialize_field("productVersion", &self.product_version)?;
-        if skip_stack {
-            s.skip_field("stack")?;
-        } else {
-            s.serialize_field("stack", &self.stack)?;
-        }
-        if skip_service {
-            s.skip_field("service")?;
-        } else {
-            s.serialize_field("service", &self.service)?;
-        }
-        if skip_environment {
-            s.skip_field("environment")?;
-        } else {
-            s.serialize_field("environment", &self.environment)?;
-        }
-        s.serialize_field("producerType", &self.producer_type)?;
-        if skip_organizations {
-            s.skip_field("organizations")?;
-        } else {
-            s.serialize_field("organizations", &self.organizations)?;
-        }
-        s.serialize_field("eventId", &self.event_id)?;
-        if skip_user_agent {
-            s.skip_field("userAgent")?;
-        } else {
-            s.serialize_field("userAgent", &self.user_agent)?;
-        }
-        if skip_categories {
-            s.skip_field("categories")?;
-        } else {
-            s.serialize_field("categories", &self.categories)?;
-        }
-        if skip_entities {
-            s.skip_field("entities")?;
-        } else {
-            s.serialize_field("entities", &self.entities)?;
-        }
-        if skip_users {
-            s.skip_field("users")?;
-        } else {
-            s.serialize_field("users", &self.users)?;
-        }
-        if skip_origins {
-            s.skip_field("origins")?;
-        } else {
-            s.serialize_field("origins", &self.origins)?;
-        }
-        if skip_source_origin {
-            s.skip_field("sourceOrigin")?;
-        } else {
-            s.serialize_field("sourceOrigin", &self.source_origin)?;
-        }
-        if skip_request_params {
-            s.skip_field("requestParams")?;
-        } else {
-            s.serialize_field("requestParams", &self.request_params)?;
-        }
-        if skip_request_fields {
-            s.skip_field("requestFields")?;
-        } else {
-            s.serialize_field("requestFields", &self.request_fields)?;
-        }
-        if skip_result_params {
-            s.skip_field("resultParams")?;
-        } else {
-            s.serialize_field("resultParams", &self.result_params)?;
-        }
-        if skip_result_fields {
-            s.skip_field("resultFields")?;
-        } else {
-            s.serialize_field("resultFields", &self.result_fields)?;
-        }
-        s.serialize_field("time", &self.time)?;
-        if skip_uid {
-            s.skip_field("uid")?;
-        } else {
-            s.serialize_field("uid", &self.uid)?;
-        }
-        if skip_sid {
-            s.skip_field("sid")?;
-        } else {
-            s.serialize_field("sid", &self.sid)?;
-        }
-        if skip_token_id {
-            s.skip_field("tokenId")?;
-        } else {
-            s.serialize_field("tokenId", &self.token_id)?;
-        }
-        if skip_org_id {
-            s.skip_field("orgId")?;
-        } else {
-            s.serialize_field("orgId", &self.org_id)?;
-        }
-        if skip_trace_id {
-            s.skip_field("traceId")?;
-        } else {
-            s.serialize_field("traceId", &self.trace_id)?;
-        }
-        if skip_origin {
-            s.skip_field("origin")?;
-        } else {
-            s.serialize_field("origin", &self.origin)?;
-        }
-        s.serialize_field("name", &self.name)?;
-        s.serialize_field("result", &self.result)?;
-        s.end()
-    }
-}
-impl<'de> de::Deserialize<'de> for AuditLogV3 {
-    fn deserialize<D>(d: D) -> Result<AuditLogV3, D::Error>
-    where
-        D: de::Deserializer<'de>,
-    {
-        d.deserialize_struct(
-            "AuditLogV3",
-            &[
-                "type",
-                "deployment",
-                "host",
-                "product",
-                "productVersion",
-                "stack",
-                "service",
-                "environment",
-                "producerType",
-                "organizations",
-                "eventId",
-                "userAgent",
-                "categories",
-                "entities",
-                "users",
-                "origins",
-                "sourceOrigin",
-                "requestParams",
-                "requestFields",
-                "resultParams",
-                "resultFields",
-                "time",
-                "uid",
-                "sid",
-                "tokenId",
-                "orgId",
-                "traceId",
-                "origin",
-                "name",
-                "result",
-            ],
-            Visitor_,
-        )
-    }
-}
-struct Visitor_;
-impl<'de> de::Visitor<'de> for Visitor_ {
-    type Value = AuditLogV3;
-    fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.write_str("map")
-    }
-    fn visit_map<A>(self, mut map_: A) -> Result<AuditLogV3, A::Error>
-    where
-        A: de::MapAccess<'de>,
-    {
-        let mut type_ = None;
-        let mut deployment = None;
-        let mut host = None;
-        let mut product = None;
-        let mut product_version = None;
-        let mut stack = None;
-        let mut service = None;
-        let mut environment = None;
-        let mut producer_type = None;
-        let mut organizations = None;
-        let mut event_id = None;
-        let mut user_agent = None;
-        let mut categories = None;
-        let mut entities = None;
-        let mut users = None;
-        let mut origins = None;
-        let mut source_origin = None;
-        let mut request_params = None;
-        let mut request_fields = None;
-        let mut result_params = None;
-        let mut result_fields = None;
-        let mut time = None;
-        let mut uid = None;
-        let mut sid = None;
-        let mut token_id = None;
-        let mut org_id = None;
-        let mut trace_id = None;
-        let mut origin = None;
-        let mut name = None;
-        let mut result = None;
-        while let Some(field_) = map_.next_key()? {
-            match field_ {
-                Field_::Type => type_ = Some(map_.next_value()?),
-                Field_::Deployment => deployment = Some(map_.next_value()?),
-                Field_::Host => host = Some(map_.next_value()?),
-                Field_::Product => product = Some(map_.next_value()?),
-                Field_::ProductVersion => product_version = Some(map_.next_value()?),
-                Field_::Stack => stack = Some(map_.next_value()?),
-                Field_::Service => service = Some(map_.next_value()?),
-                Field_::Environment => environment = Some(map_.next_value()?),
-                Field_::ProducerType => producer_type = Some(map_.next_value()?),
-                Field_::Organizations => organizations = Some(map_.next_value()?),
-                Field_::EventId => event_id = Some(map_.next_value()?),
-                Field_::UserAgent => user_agent = Some(map_.next_value()?),
-                Field_::Categories => categories = Some(map_.next_value()?),
-                Field_::Entities => entities = Some(map_.next_value()?),
-                Field_::Users => users = Some(map_.next_value()?),
-                Field_::Origins => origins = Some(map_.next_value()?),
-                Field_::SourceOrigin => source_origin = Some(map_.next_value()?),
-                Field_::RequestParams => request_params = Some(map_.next_value()?),
-                Field_::RequestFields => request_fields = Some(map_.next_value()?),
-                Field_::ResultParams => result_params = Some(map_.next_value()?),
-                Field_::ResultFields => result_fields = Some(map_.next_value()?),
-                Field_::Time => time = Some(map_.next_value()?),
-                Field_::Uid => uid = Some(map_.next_value()?),
-                Field_::Sid => sid = Some(map_.next_value()?),
-                Field_::TokenId => token_id = Some(map_.next_value()?),
-                Field_::OrgId => org_id = Some(map_.next_value()?),
-                Field_::TraceId => trace_id = Some(map_.next_value()?),
-                Field_::Origin => origin = Some(map_.next_value()?),
-                Field_::Name => name = Some(map_.next_value()?),
-                Field_::Result => result = Some(map_.next_value()?),
-                Field_::Unknown_ => {
-                    map_.next_value::<de::IgnoredAny>()?;
-                }
-            }
-        }
-        let type_ = match type_ {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("type")),
-        };
-        let deployment = match deployment {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("deployment")),
-        };
-        let host = match host {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("host")),
-        };
-        let product = match product {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("product")),
-        };
-        let product_version = match product_version {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("productVersion")),
-        };
-        let stack = match stack {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let service = match service {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let environment = match environment {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let producer_type = match producer_type {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("producerType")),
-        };
-        let organizations = match organizations {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let event_id = match event_id {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("eventId")),
-        };
-        let user_agent = match user_agent {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let categories = match categories {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let entities = match entities {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let users = match users {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let origins = match origins {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let source_origin = match source_origin {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let request_params = match request_params {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let request_fields = match request_fields {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let result_params = match result_params {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let result_fields = match result_fields {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let time = match time {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("time")),
-        };
-        let uid = match uid {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let sid = match sid {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let token_id = match token_id {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let org_id = match org_id {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let trace_id = match trace_id {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let origin = match origin {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let name = match name {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("name")),
-        };
-        let result = match result {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("result")),
-        };
-        Ok(AuditLogV3 {
-            type_,
-            deployment,
-            host,
-            product,
-            product_version,
-            stack,
-            service,
-            environment,
-            producer_type,
-            organizations,
-            event_id,
-            user_agent,
-            categories,
-            entities,
-            users,
-            origins,
-            source_origin,
-            request_params,
-            request_fields,
-            result_params,
-            result_fields,
-            time,
-            uid,
-            sid,
-            token_id,
-            org_id,
-            trace_id,
-            origin,
-            name,
-            result,
-        })
-    }
-}
-enum Field_ {
-    Type,
-    Deployment,
-    Host,
-    Product,
-    ProductVersion,
-    Stack,
-    Service,
-    Environment,
-    ProducerType,
-    Organizations,
-    EventId,
-    UserAgent,
-    Categories,
-    Entities,
-    Users,
-    Origins,
-    SourceOrigin,
-    RequestParams,
-    RequestFields,
-    ResultParams,
-    ResultFields,
-    Time,
-    Uid,
-    Sid,
-    TokenId,
-    OrgId,
-    TraceId,
-    Origin,
-    Name,
-    Result,
-    Unknown_,
-}
-impl<'de> de::Deserialize<'de> for Field_ {
-    fn deserialize<D>(d: D) -> Result<Field_, D::Error>
-    where
-        D: de::Deserializer<'de>,
-    {
-        d.deserialize_str(FieldVisitor_)
-    }
-}
-struct FieldVisitor_;
-impl<'de> de::Visitor<'de> for FieldVisitor_ {
-    type Value = Field_;
-    fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.write_str("string")
-    }
-    fn visit_str<E>(self, value: &str) -> Result<Field_, E>
-    where
-        E: de::Error,
-    {
-        let v = match value {
-            "type" => Field_::Type,
-            "deployment" => Field_::Deployment,
-            "host" => Field_::Host,
-            "product" => Field_::Product,
-            "productVersion" => Field_::ProductVersion,
-            "stack" => Field_::Stack,
-            "service" => Field_::Service,
-            "environment" => Field_::Environment,
-            "producerType" => Field_::ProducerType,
-            "organizations" => Field_::Organizations,
-            "eventId" => Field_::EventId,
-            "userAgent" => Field_::UserAgent,
-            "categories" => Field_::Categories,
-            "entities" => Field_::Entities,
-            "users" => Field_::Users,
-            "origins" => Field_::Origins,
-            "sourceOrigin" => Field_::SourceOrigin,
-            "requestParams" => Field_::RequestParams,
-            "requestFields" => Field_::RequestFields,
-            "resultParams" => Field_::ResultParams,
-            "resultFields" => Field_::ResultFields,
-            "time" => Field_::Time,
-            "uid" => Field_::Uid,
-            "sid" => Field_::Sid,
-            "tokenId" => Field_::TokenId,
-            "orgId" => Field_::OrgId,
-            "traceId" => Field_::TraceId,
-            "origin" => Field_::Origin,
-            "name" => Field_::Name,
-            "result" => Field_::Result,
-            _ => Field_::Unknown_,
-        };
-        Ok(v)
     }
 }

--- a/witchcraft-server/src/logging/api/audit_producer.rs
+++ b/witchcraft-server/src/logging/api/audit_producer.rs
@@ -1,9 +1,22 @@
-use conjure_object::serde::{ser, de};
+#![allow(deprecated)]
 use std::fmt;
 use std::str;
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    conjure_object::serde::Deserialize,
+    conjure_object::serde::Serialize,
+)]
+#[serde(crate = "conjure_object::serde")]
 pub enum AuditProducer {
+    #[serde(rename = "SERVER")]
     Server,
+    #[serde(rename = "CLIENT")]
     Client,
 }
 impl AuditProducer {
@@ -46,37 +59,5 @@ impl conjure_object::FromPlain for AuditProducer {
         v: &str,
     ) -> Result<AuditProducer, conjure_object::plain::ParseEnumError> {
         v.parse()
-    }
-}
-impl ser::Serialize for AuditProducer {
-    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
-    where
-        S: ser::Serializer,
-    {
-        s.serialize_str(self.as_str())
-    }
-}
-impl<'de> de::Deserialize<'de> for AuditProducer {
-    fn deserialize<D>(d: D) -> Result<AuditProducer, D::Error>
-    where
-        D: de::Deserializer<'de>,
-    {
-        d.deserialize_str(Visitor_)
-    }
-}
-struct Visitor_;
-impl<'de> de::Visitor<'de> for Visitor_ {
-    type Value = AuditProducer;
-    fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.write_str("a string")
-    }
-    fn visit_str<E>(self, v: &str) -> Result<AuditProducer, E>
-    where
-        E: de::Error,
-    {
-        match v.parse() {
-            Ok(e) => Ok(e),
-            Err(_) => Err(de::Error::unknown_variant(v, &["SERVER", "CLIENT"])),
-        }
     }
 }

--- a/witchcraft-server/src/logging/api/audit_result.rs
+++ b/witchcraft-server/src/logging/api/audit_result.rs
@@ -1,12 +1,27 @@
-use conjure_object::serde::{ser, de};
+#![allow(deprecated)]
 use std::fmt;
 use std::str;
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    conjure_object::serde::Deserialize,
+    conjure_object::serde::Serialize,
+)]
+#[serde(crate = "conjure_object::serde")]
 pub enum AuditResult {
+    #[serde(rename = "SUCCESS")]
     Success,
+    #[serde(rename = "ERROR")]
     Error,
+    #[serde(rename = "UNAUTHORIZED")]
     Unauthorized,
     ///A result that has not yet been finalized. It may be missing fields from resultParams, and it is expected that a non-partial log should occur in the future with the same event ID.
+    #[serde(rename = "PARTIAL")]
     Partial,
 }
 impl AuditResult {
@@ -51,44 +66,5 @@ impl conjure_object::FromPlain for AuditResult {
         v: &str,
     ) -> Result<AuditResult, conjure_object::plain::ParseEnumError> {
         v.parse()
-    }
-}
-impl ser::Serialize for AuditResult {
-    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
-    where
-        S: ser::Serializer,
-    {
-        s.serialize_str(self.as_str())
-    }
-}
-impl<'de> de::Deserialize<'de> for AuditResult {
-    fn deserialize<D>(d: D) -> Result<AuditResult, D::Error>
-    where
-        D: de::Deserializer<'de>,
-    {
-        d.deserialize_str(Visitor_)
-    }
-}
-struct Visitor_;
-impl<'de> de::Visitor<'de> for Visitor_ {
-    type Value = AuditResult;
-    fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.write_str("a string")
-    }
-    fn visit_str<E>(self, v: &str) -> Result<AuditResult, E>
-    where
-        E: de::Error,
-    {
-        match v.parse() {
-            Ok(e) => Ok(e),
-            Err(_) => {
-                Err(
-                    de::Error::unknown_variant(
-                        v,
-                        &["SUCCESS", "ERROR", "UNAUTHORIZED", "PARTIAL"],
-                    ),
-                )
-            }
-        }
     }
 }

--- a/witchcraft-server/src/logging/api/contextualized_user.rs
+++ b/witchcraft-server/src/logging/api/contextualized_user.rs
@@ -1,20 +1,34 @@
-use conjure_object::serde::{ser, de};
-use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use std::fmt;
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+    Debug,
+    Clone,
+    conjure_object::serde::Serialize,
+    conjure_object::serde::Deserialize,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash
+)]
+#[serde(crate = "conjure_object::serde")]
 #[conjure_object::private::staged_builder::staged_builder]
 #[builder(crate = conjure_object::private::staged_builder, update, inline)]
 pub struct ContextualizedUser {
+    #[serde(rename = "uid")]
     uid: super::UserId,
     #[builder(default, into)]
+    #[serde(rename = "userName", skip_serializing_if = "Option::is_none", default)]
     user_name: Option<String>,
     #[builder(default, into)]
+    #[serde(rename = "firstName", skip_serializing_if = "Option::is_none", default)]
     first_name: Option<String>,
     #[builder(default, into)]
+    #[serde(rename = "lastName", skip_serializing_if = "Option::is_none", default)]
     last_name: Option<String>,
     #[builder(default, list(item(type = String, into)))]
+    #[serde(rename = "groups", skip_serializing_if = "Vec::is_empty", default)]
     groups: Vec<String>,
     #[builder(default, into)]
+    #[serde(rename = "realm", skip_serializing_if = "Option::is_none", default)]
     realm: Option<String>,
 }
 impl ContextualizedUser {
@@ -46,175 +60,5 @@ impl ContextualizedUser {
     #[inline]
     pub fn realm(&self) -> Option<&str> {
         self.realm.as_ref().map(|o| &**o)
-    }
-}
-impl ser::Serialize for ContextualizedUser {
-    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
-    where
-        S: ser::Serializer,
-    {
-        let mut size = 1usize;
-        let skip_user_name = self.user_name.is_none();
-        if !skip_user_name {
-            size += 1;
-        }
-        let skip_first_name = self.first_name.is_none();
-        if !skip_first_name {
-            size += 1;
-        }
-        let skip_last_name = self.last_name.is_none();
-        if !skip_last_name {
-            size += 1;
-        }
-        let skip_groups = self.groups.is_empty();
-        if !skip_groups {
-            size += 1;
-        }
-        let skip_realm = self.realm.is_none();
-        if !skip_realm {
-            size += 1;
-        }
-        let mut s = s.serialize_struct("ContextualizedUser", size)?;
-        s.serialize_field("uid", &self.uid)?;
-        if skip_user_name {
-            s.skip_field("userName")?;
-        } else {
-            s.serialize_field("userName", &self.user_name)?;
-        }
-        if skip_first_name {
-            s.skip_field("firstName")?;
-        } else {
-            s.serialize_field("firstName", &self.first_name)?;
-        }
-        if skip_last_name {
-            s.skip_field("lastName")?;
-        } else {
-            s.serialize_field("lastName", &self.last_name)?;
-        }
-        if skip_groups {
-            s.skip_field("groups")?;
-        } else {
-            s.serialize_field("groups", &self.groups)?;
-        }
-        if skip_realm {
-            s.skip_field("realm")?;
-        } else {
-            s.serialize_field("realm", &self.realm)?;
-        }
-        s.end()
-    }
-}
-impl<'de> de::Deserialize<'de> for ContextualizedUser {
-    fn deserialize<D>(d: D) -> Result<ContextualizedUser, D::Error>
-    where
-        D: de::Deserializer<'de>,
-    {
-        d.deserialize_struct(
-            "ContextualizedUser",
-            &["uid", "userName", "firstName", "lastName", "groups", "realm"],
-            Visitor_,
-        )
-    }
-}
-struct Visitor_;
-impl<'de> de::Visitor<'de> for Visitor_ {
-    type Value = ContextualizedUser;
-    fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.write_str("map")
-    }
-    fn visit_map<A>(self, mut map_: A) -> Result<ContextualizedUser, A::Error>
-    where
-        A: de::MapAccess<'de>,
-    {
-        let mut uid = None;
-        let mut user_name = None;
-        let mut first_name = None;
-        let mut last_name = None;
-        let mut groups = None;
-        let mut realm = None;
-        while let Some(field_) = map_.next_key()? {
-            match field_ {
-                Field_::Uid => uid = Some(map_.next_value()?),
-                Field_::UserName => user_name = Some(map_.next_value()?),
-                Field_::FirstName => first_name = Some(map_.next_value()?),
-                Field_::LastName => last_name = Some(map_.next_value()?),
-                Field_::Groups => groups = Some(map_.next_value()?),
-                Field_::Realm => realm = Some(map_.next_value()?),
-                Field_::Unknown_ => {
-                    map_.next_value::<de::IgnoredAny>()?;
-                }
-            }
-        }
-        let uid = match uid {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("uid")),
-        };
-        let user_name = match user_name {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let first_name = match first_name {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let last_name = match last_name {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let groups = match groups {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let realm = match realm {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        Ok(ContextualizedUser {
-            uid,
-            user_name,
-            first_name,
-            last_name,
-            groups,
-            realm,
-        })
-    }
-}
-enum Field_ {
-    Uid,
-    UserName,
-    FirstName,
-    LastName,
-    Groups,
-    Realm,
-    Unknown_,
-}
-impl<'de> de::Deserialize<'de> for Field_ {
-    fn deserialize<D>(d: D) -> Result<Field_, D::Error>
-    where
-        D: de::Deserializer<'de>,
-    {
-        d.deserialize_str(FieldVisitor_)
-    }
-}
-struct FieldVisitor_;
-impl<'de> de::Visitor<'de> for FieldVisitor_ {
-    type Value = Field_;
-    fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.write_str("string")
-    }
-    fn visit_str<E>(self, value: &str) -> Result<Field_, E>
-    where
-        E: de::Error,
-    {
-        let v = match value {
-            "uid" => Field_::Uid,
-            "userName" => Field_::UserName,
-            "firstName" => Field_::FirstName,
-            "lastName" => Field_::LastName,
-            "groups" => Field_::Groups,
-            "realm" => Field_::Realm,
-            _ => Field_::Unknown_,
-        };
-        Ok(v)
     }
 }

--- a/witchcraft-server/src/logging/api/diagnostic_log_v1.rs
+++ b/witchcraft-server/src/logging/api/diagnostic_log_v1.rs
@@ -1,15 +1,26 @@
-use conjure_object::serde::{ser, de};
-use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use std::fmt;
 ///Definition of the diagnostic.1 format.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+    Debug,
+    Clone,
+    conjure_object::serde::Serialize,
+    conjure_object::serde::Deserialize,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash
+)]
+#[serde(crate = "conjure_object::serde")]
 #[conjure_object::private::staged_builder::staged_builder]
 #[builder(crate = conjure_object::private::staged_builder, update, inline)]
 pub struct DiagnosticLogV1 {
     #[builder(into)]
+    #[serde(rename = "type")]
     type_: String,
+    #[serde(rename = "time")]
     time: conjure_object::DateTime<conjure_object::Utc>,
     #[builder(custom(type = super::Diagnostic, convert = Box::new))]
+    #[serde(rename = "diagnostic")]
     diagnostic: Box<super::Diagnostic>,
     #[builder(
         default,
@@ -25,6 +36,11 @@ pub struct DiagnosticLogV1 {
                 )
             )
         )
+    )]
+    #[serde(
+        rename = "unsafeParams",
+        skip_serializing_if = "std::collections::BTreeMap::is_empty",
+        default
     )]
     unsafe_params: std::collections::BTreeMap<String, conjure_object::Any>,
 }
@@ -58,123 +74,5 @@ impl DiagnosticLogV1 {
         &self,
     ) -> &std::collections::BTreeMap<String, conjure_object::Any> {
         &self.unsafe_params
-    }
-}
-impl ser::Serialize for DiagnosticLogV1 {
-    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
-    where
-        S: ser::Serializer,
-    {
-        let mut size = 3usize;
-        let skip_unsafe_params = self.unsafe_params.is_empty();
-        if !skip_unsafe_params {
-            size += 1;
-        }
-        let mut s = s.serialize_struct("DiagnosticLogV1", size)?;
-        s.serialize_field("type", &self.type_)?;
-        s.serialize_field("time", &self.time)?;
-        s.serialize_field("diagnostic", &self.diagnostic)?;
-        if skip_unsafe_params {
-            s.skip_field("unsafeParams")?;
-        } else {
-            s.serialize_field("unsafeParams", &self.unsafe_params)?;
-        }
-        s.end()
-    }
-}
-impl<'de> de::Deserialize<'de> for DiagnosticLogV1 {
-    fn deserialize<D>(d: D) -> Result<DiagnosticLogV1, D::Error>
-    where
-        D: de::Deserializer<'de>,
-    {
-        d.deserialize_struct(
-            "DiagnosticLogV1",
-            &["type", "time", "diagnostic", "unsafeParams"],
-            Visitor_,
-        )
-    }
-}
-struct Visitor_;
-impl<'de> de::Visitor<'de> for Visitor_ {
-    type Value = DiagnosticLogV1;
-    fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.write_str("map")
-    }
-    fn visit_map<A>(self, mut map_: A) -> Result<DiagnosticLogV1, A::Error>
-    where
-        A: de::MapAccess<'de>,
-    {
-        let mut type_ = None;
-        let mut time = None;
-        let mut diagnostic = None;
-        let mut unsafe_params = None;
-        while let Some(field_) = map_.next_key()? {
-            match field_ {
-                Field_::Type => type_ = Some(map_.next_value()?),
-                Field_::Time => time = Some(map_.next_value()?),
-                Field_::Diagnostic => diagnostic = Some(map_.next_value()?),
-                Field_::UnsafeParams => unsafe_params = Some(map_.next_value()?),
-                Field_::Unknown_ => {
-                    map_.next_value::<de::IgnoredAny>()?;
-                }
-            }
-        }
-        let type_ = match type_ {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("type")),
-        };
-        let time = match time {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("time")),
-        };
-        let diagnostic = match diagnostic {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("diagnostic")),
-        };
-        let unsafe_params = match unsafe_params {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        Ok(DiagnosticLogV1 {
-            type_,
-            time,
-            diagnostic,
-            unsafe_params,
-        })
-    }
-}
-enum Field_ {
-    Type,
-    Time,
-    Diagnostic,
-    UnsafeParams,
-    Unknown_,
-}
-impl<'de> de::Deserialize<'de> for Field_ {
-    fn deserialize<D>(d: D) -> Result<Field_, D::Error>
-    where
-        D: de::Deserializer<'de>,
-    {
-        d.deserialize_str(FieldVisitor_)
-    }
-}
-struct FieldVisitor_;
-impl<'de> de::Visitor<'de> for FieldVisitor_ {
-    type Value = Field_;
-    fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.write_str("string")
-    }
-    fn visit_str<E>(self, value: &str) -> Result<Field_, E>
-    where
-        E: de::Error,
-    {
-        let v = match value {
-            "type" => Field_::Type,
-            "time" => Field_::Time,
-            "diagnostic" => Field_::Diagnostic,
-            "unsafeParams" => Field_::UnsafeParams,
-            _ => Field_::Unknown_,
-        };
-        Ok(v)
     }
 }

--- a/witchcraft-server/src/logging/api/endpoint.rs
+++ b/witchcraft-server/src/logging/api/endpoint.rs
@@ -1,15 +1,26 @@
-use conjure_object::serde::{ser, de};
-use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use std::fmt;
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+    Debug,
+    Clone,
+    conjure_object::serde::Serialize,
+    conjure_object::serde::Deserialize,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash
+)]
+#[serde(crate = "conjure_object::serde")]
 #[conjure_object::private::staged_builder::staged_builder]
 #[builder(crate = conjure_object::private::staged_builder, update, inline)]
 pub struct Endpoint {
     #[builder(into)]
+    #[serde(rename = "serviceName")]
     service_name: String,
     #[builder(default, into)]
+    #[serde(rename = "ipv4", skip_serializing_if = "Option::is_none", default)]
     ipv4: Option<String>,
     #[builder(default, into)]
+    #[serde(rename = "ipv6", skip_serializing_if = "Option::is_none", default)]
     ipv6: Option<String>,
 }
 impl Endpoint {
@@ -32,117 +43,5 @@ impl Endpoint {
     #[inline]
     pub fn ipv6(&self) -> Option<&str> {
         self.ipv6.as_ref().map(|o| &**o)
-    }
-}
-impl ser::Serialize for Endpoint {
-    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
-    where
-        S: ser::Serializer,
-    {
-        let mut size = 1usize;
-        let skip_ipv4 = self.ipv4.is_none();
-        if !skip_ipv4 {
-            size += 1;
-        }
-        let skip_ipv6 = self.ipv6.is_none();
-        if !skip_ipv6 {
-            size += 1;
-        }
-        let mut s = s.serialize_struct("Endpoint", size)?;
-        s.serialize_field("serviceName", &self.service_name)?;
-        if skip_ipv4 {
-            s.skip_field("ipv4")?;
-        } else {
-            s.serialize_field("ipv4", &self.ipv4)?;
-        }
-        if skip_ipv6 {
-            s.skip_field("ipv6")?;
-        } else {
-            s.serialize_field("ipv6", &self.ipv6)?;
-        }
-        s.end()
-    }
-}
-impl<'de> de::Deserialize<'de> for Endpoint {
-    fn deserialize<D>(d: D) -> Result<Endpoint, D::Error>
-    where
-        D: de::Deserializer<'de>,
-    {
-        d.deserialize_struct("Endpoint", &["serviceName", "ipv4", "ipv6"], Visitor_)
-    }
-}
-struct Visitor_;
-impl<'de> de::Visitor<'de> for Visitor_ {
-    type Value = Endpoint;
-    fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.write_str("map")
-    }
-    fn visit_map<A>(self, mut map_: A) -> Result<Endpoint, A::Error>
-    where
-        A: de::MapAccess<'de>,
-    {
-        let mut service_name = None;
-        let mut ipv4 = None;
-        let mut ipv6 = None;
-        while let Some(field_) = map_.next_key()? {
-            match field_ {
-                Field_::ServiceName => service_name = Some(map_.next_value()?),
-                Field_::Ipv4 => ipv4 = Some(map_.next_value()?),
-                Field_::Ipv6 => ipv6 = Some(map_.next_value()?),
-                Field_::Unknown_ => {
-                    map_.next_value::<de::IgnoredAny>()?;
-                }
-            }
-        }
-        let service_name = match service_name {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("serviceName")),
-        };
-        let ipv4 = match ipv4 {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let ipv6 = match ipv6 {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        Ok(Endpoint {
-            service_name,
-            ipv4,
-            ipv6,
-        })
-    }
-}
-enum Field_ {
-    ServiceName,
-    Ipv4,
-    Ipv6,
-    Unknown_,
-}
-impl<'de> de::Deserialize<'de> for Field_ {
-    fn deserialize<D>(d: D) -> Result<Field_, D::Error>
-    where
-        D: de::Deserializer<'de>,
-    {
-        d.deserialize_str(FieldVisitor_)
-    }
-}
-struct FieldVisitor_;
-impl<'de> de::Visitor<'de> for FieldVisitor_ {
-    type Value = Field_;
-    fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.write_str("string")
-    }
-    fn visit_str<E>(self, value: &str) -> Result<Field_, E>
-    where
-        E: de::Error,
-    {
-        let v = match value {
-            "serviceName" => Field_::ServiceName,
-            "ipv4" => Field_::Ipv4,
-            "ipv6" => Field_::Ipv6,
-            _ => Field_::Unknown_,
-        };
-        Ok(v)
     }
 }

--- a/witchcraft-server/src/logging/api/event_log_v1.rs
+++ b/witchcraft-server/src/logging/api/event_log_v1.rs
@@ -1,17 +1,29 @@
-use conjure_object::serde::{ser, de};
-use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use std::fmt;
 ///Definition of the event.1 format.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+    Debug,
+    Clone,
+    conjure_object::serde::Serialize,
+    conjure_object::serde::Deserialize,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash
+)]
+#[serde(crate = "conjure_object::serde")]
 #[conjure_object::private::staged_builder::staged_builder]
 #[builder(crate = conjure_object::private::staged_builder, update, inline)]
 pub struct EventLogV1 {
     #[builder(into)]
+    #[serde(rename = "type")]
     type_: String,
+    #[serde(rename = "time")]
     time: conjure_object::DateTime<conjure_object::Utc>,
     #[builder(into)]
+    #[serde(rename = "eventName")]
     event_name: String,
     #[builder(into)]
+    #[serde(rename = "eventType")]
     event_type: String,
     #[builder(
         default,
@@ -28,14 +40,23 @@ pub struct EventLogV1 {
             )
         )
     )]
+    #[serde(
+        rename = "values",
+        skip_serializing_if = "std::collections::BTreeMap::is_empty",
+        default
+    )]
     values: std::collections::BTreeMap<String, conjure_object::Any>,
     #[builder(default, into)]
+    #[serde(rename = "uid", skip_serializing_if = "Option::is_none", default)]
     uid: Option<super::UserId>,
     #[builder(default, into)]
+    #[serde(rename = "sid", skip_serializing_if = "Option::is_none", default)]
     sid: Option<super::SessionId>,
     #[builder(default, into)]
+    #[serde(rename = "tokenId", skip_serializing_if = "Option::is_none", default)]
     token_id: Option<super::TokenId>,
     #[builder(default, into)]
+    #[serde(rename = "orgId", skip_serializing_if = "Option::is_none", default)]
     org_id: Option<super::OrganizationId>,
     #[builder(
         default,
@@ -51,6 +72,11 @@ pub struct EventLogV1 {
                 )
             )
         )
+    )]
+    #[serde(
+        rename = "unsafeParams",
+        skip_serializing_if = "std::collections::BTreeMap::is_empty",
+        default
     )]
     unsafe_params: std::collections::BTreeMap<String, conjure_object::Any>,
 }
@@ -104,234 +130,5 @@ impl EventLogV1 {
         &self,
     ) -> &std::collections::BTreeMap<String, conjure_object::Any> {
         &self.unsafe_params
-    }
-}
-impl ser::Serialize for EventLogV1 {
-    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
-    where
-        S: ser::Serializer,
-    {
-        let mut size = 4usize;
-        let skip_values = self.values.is_empty();
-        if !skip_values {
-            size += 1;
-        }
-        let skip_uid = self.uid.is_none();
-        if !skip_uid {
-            size += 1;
-        }
-        let skip_sid = self.sid.is_none();
-        if !skip_sid {
-            size += 1;
-        }
-        let skip_token_id = self.token_id.is_none();
-        if !skip_token_id {
-            size += 1;
-        }
-        let skip_org_id = self.org_id.is_none();
-        if !skip_org_id {
-            size += 1;
-        }
-        let skip_unsafe_params = self.unsafe_params.is_empty();
-        if !skip_unsafe_params {
-            size += 1;
-        }
-        let mut s = s.serialize_struct("EventLogV1", size)?;
-        s.serialize_field("type", &self.type_)?;
-        s.serialize_field("time", &self.time)?;
-        s.serialize_field("eventName", &self.event_name)?;
-        s.serialize_field("eventType", &self.event_type)?;
-        if skip_values {
-            s.skip_field("values")?;
-        } else {
-            s.serialize_field("values", &self.values)?;
-        }
-        if skip_uid {
-            s.skip_field("uid")?;
-        } else {
-            s.serialize_field("uid", &self.uid)?;
-        }
-        if skip_sid {
-            s.skip_field("sid")?;
-        } else {
-            s.serialize_field("sid", &self.sid)?;
-        }
-        if skip_token_id {
-            s.skip_field("tokenId")?;
-        } else {
-            s.serialize_field("tokenId", &self.token_id)?;
-        }
-        if skip_org_id {
-            s.skip_field("orgId")?;
-        } else {
-            s.serialize_field("orgId", &self.org_id)?;
-        }
-        if skip_unsafe_params {
-            s.skip_field("unsafeParams")?;
-        } else {
-            s.serialize_field("unsafeParams", &self.unsafe_params)?;
-        }
-        s.end()
-    }
-}
-impl<'de> de::Deserialize<'de> for EventLogV1 {
-    fn deserialize<D>(d: D) -> Result<EventLogV1, D::Error>
-    where
-        D: de::Deserializer<'de>,
-    {
-        d.deserialize_struct(
-            "EventLogV1",
-            &[
-                "type",
-                "time",
-                "eventName",
-                "eventType",
-                "values",
-                "uid",
-                "sid",
-                "tokenId",
-                "orgId",
-                "unsafeParams",
-            ],
-            Visitor_,
-        )
-    }
-}
-struct Visitor_;
-impl<'de> de::Visitor<'de> for Visitor_ {
-    type Value = EventLogV1;
-    fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.write_str("map")
-    }
-    fn visit_map<A>(self, mut map_: A) -> Result<EventLogV1, A::Error>
-    where
-        A: de::MapAccess<'de>,
-    {
-        let mut type_ = None;
-        let mut time = None;
-        let mut event_name = None;
-        let mut event_type = None;
-        let mut values = None;
-        let mut uid = None;
-        let mut sid = None;
-        let mut token_id = None;
-        let mut org_id = None;
-        let mut unsafe_params = None;
-        while let Some(field_) = map_.next_key()? {
-            match field_ {
-                Field_::Type => type_ = Some(map_.next_value()?),
-                Field_::Time => time = Some(map_.next_value()?),
-                Field_::EventName => event_name = Some(map_.next_value()?),
-                Field_::EventType => event_type = Some(map_.next_value()?),
-                Field_::Values => values = Some(map_.next_value()?),
-                Field_::Uid => uid = Some(map_.next_value()?),
-                Field_::Sid => sid = Some(map_.next_value()?),
-                Field_::TokenId => token_id = Some(map_.next_value()?),
-                Field_::OrgId => org_id = Some(map_.next_value()?),
-                Field_::UnsafeParams => unsafe_params = Some(map_.next_value()?),
-                Field_::Unknown_ => {
-                    map_.next_value::<de::IgnoredAny>()?;
-                }
-            }
-        }
-        let type_ = match type_ {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("type")),
-        };
-        let time = match time {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("time")),
-        };
-        let event_name = match event_name {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("eventName")),
-        };
-        let event_type = match event_type {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("eventType")),
-        };
-        let values = match values {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let uid = match uid {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let sid = match sid {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let token_id = match token_id {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let org_id = match org_id {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let unsafe_params = match unsafe_params {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        Ok(EventLogV1 {
-            type_,
-            time,
-            event_name,
-            event_type,
-            values,
-            uid,
-            sid,
-            token_id,
-            org_id,
-            unsafe_params,
-        })
-    }
-}
-enum Field_ {
-    Type,
-    Time,
-    EventName,
-    EventType,
-    Values,
-    Uid,
-    Sid,
-    TokenId,
-    OrgId,
-    UnsafeParams,
-    Unknown_,
-}
-impl<'de> de::Deserialize<'de> for Field_ {
-    fn deserialize<D>(d: D) -> Result<Field_, D::Error>
-    where
-        D: de::Deserializer<'de>,
-    {
-        d.deserialize_str(FieldVisitor_)
-    }
-}
-struct FieldVisitor_;
-impl<'de> de::Visitor<'de> for FieldVisitor_ {
-    type Value = Field_;
-    fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.write_str("string")
-    }
-    fn visit_str<E>(self, value: &str) -> Result<Field_, E>
-    where
-        E: de::Error,
-    {
-        let v = match value {
-            "type" => Field_::Type,
-            "time" => Field_::Time,
-            "eventName" => Field_::EventName,
-            "eventType" => Field_::EventType,
-            "values" => Field_::Values,
-            "uid" => Field_::Uid,
-            "sid" => Field_::Sid,
-            "tokenId" => Field_::TokenId,
-            "orgId" => Field_::OrgId,
-            "unsafeParams" => Field_::UnsafeParams,
-            _ => Field_::Unknown_,
-        };
-        Ok(v)
     }
 }

--- a/witchcraft-server/src/logging/api/event_log_v2.rs
+++ b/witchcraft-server/src/logging/api/event_log_v2.rs
@@ -1,15 +1,26 @@
-use conjure_object::serde::{ser, de};
-use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use std::fmt;
 ///Definition of the event.2 format.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+    Debug,
+    Clone,
+    conjure_object::serde::Serialize,
+    conjure_object::serde::Deserialize,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash
+)]
+#[serde(crate = "conjure_object::serde")]
 #[conjure_object::private::staged_builder::staged_builder]
 #[builder(crate = conjure_object::private::staged_builder, update, inline)]
 pub struct EventLogV2 {
     #[builder(into)]
+    #[serde(rename = "type")]
     type_: String,
+    #[serde(rename = "time")]
     time: conjure_object::DateTime<conjure_object::Utc>,
     #[builder(into)]
+    #[serde(rename = "eventName")]
     event_name: String,
     #[builder(
         default,
@@ -26,16 +37,26 @@ pub struct EventLogV2 {
             )
         )
     )]
+    #[serde(
+        rename = "values",
+        skip_serializing_if = "std::collections::BTreeMap::is_empty",
+        default
+    )]
     values: std::collections::BTreeMap<String, conjure_object::Any>,
     #[builder(default, into)]
+    #[serde(rename = "uid", skip_serializing_if = "Option::is_none", default)]
     uid: Option<super::UserId>,
     #[builder(default, into)]
+    #[serde(rename = "sid", skip_serializing_if = "Option::is_none", default)]
     sid: Option<super::SessionId>,
     #[builder(default, into)]
+    #[serde(rename = "tokenId", skip_serializing_if = "Option::is_none", default)]
     token_id: Option<super::TokenId>,
     #[builder(default, into)]
+    #[serde(rename = "orgId", skip_serializing_if = "Option::is_none", default)]
     org_id: Option<super::OrganizationId>,
     #[builder(default, into)]
+    #[serde(rename = "traceId", skip_serializing_if = "Option::is_none", default)]
     trace_id: Option<super::TraceId>,
     #[builder(
         default,
@@ -52,8 +73,18 @@ pub struct EventLogV2 {
             )
         )
     )]
+    #[serde(
+        rename = "unsafeParams",
+        skip_serializing_if = "std::collections::BTreeMap::is_empty",
+        default
+    )]
     unsafe_params: std::collections::BTreeMap<String, conjure_object::Any>,
     #[builder(default, map(key(type = String, into), value(type = String, into)))]
+    #[serde(
+        rename = "tags",
+        skip_serializing_if = "std::collections::BTreeMap::is_empty",
+        default
+    )]
     tags: std::collections::BTreeMap<String, String>,
 }
 impl EventLogV2 {
@@ -120,261 +151,5 @@ impl EventLogV2 {
     #[inline]
     pub fn tags(&self) -> &std::collections::BTreeMap<String, String> {
         &self.tags
-    }
-}
-impl ser::Serialize for EventLogV2 {
-    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
-    where
-        S: ser::Serializer,
-    {
-        let mut size = 3usize;
-        let skip_values = self.values.is_empty();
-        if !skip_values {
-            size += 1;
-        }
-        let skip_uid = self.uid.is_none();
-        if !skip_uid {
-            size += 1;
-        }
-        let skip_sid = self.sid.is_none();
-        if !skip_sid {
-            size += 1;
-        }
-        let skip_token_id = self.token_id.is_none();
-        if !skip_token_id {
-            size += 1;
-        }
-        let skip_org_id = self.org_id.is_none();
-        if !skip_org_id {
-            size += 1;
-        }
-        let skip_trace_id = self.trace_id.is_none();
-        if !skip_trace_id {
-            size += 1;
-        }
-        let skip_unsafe_params = self.unsafe_params.is_empty();
-        if !skip_unsafe_params {
-            size += 1;
-        }
-        let skip_tags = self.tags.is_empty();
-        if !skip_tags {
-            size += 1;
-        }
-        let mut s = s.serialize_struct("EventLogV2", size)?;
-        s.serialize_field("type", &self.type_)?;
-        s.serialize_field("time", &self.time)?;
-        s.serialize_field("eventName", &self.event_name)?;
-        if skip_values {
-            s.skip_field("values")?;
-        } else {
-            s.serialize_field("values", &self.values)?;
-        }
-        if skip_uid {
-            s.skip_field("uid")?;
-        } else {
-            s.serialize_field("uid", &self.uid)?;
-        }
-        if skip_sid {
-            s.skip_field("sid")?;
-        } else {
-            s.serialize_field("sid", &self.sid)?;
-        }
-        if skip_token_id {
-            s.skip_field("tokenId")?;
-        } else {
-            s.serialize_field("tokenId", &self.token_id)?;
-        }
-        if skip_org_id {
-            s.skip_field("orgId")?;
-        } else {
-            s.serialize_field("orgId", &self.org_id)?;
-        }
-        if skip_trace_id {
-            s.skip_field("traceId")?;
-        } else {
-            s.serialize_field("traceId", &self.trace_id)?;
-        }
-        if skip_unsafe_params {
-            s.skip_field("unsafeParams")?;
-        } else {
-            s.serialize_field("unsafeParams", &self.unsafe_params)?;
-        }
-        if skip_tags {
-            s.skip_field("tags")?;
-        } else {
-            s.serialize_field("tags", &self.tags)?;
-        }
-        s.end()
-    }
-}
-impl<'de> de::Deserialize<'de> for EventLogV2 {
-    fn deserialize<D>(d: D) -> Result<EventLogV2, D::Error>
-    where
-        D: de::Deserializer<'de>,
-    {
-        d.deserialize_struct(
-            "EventLogV2",
-            &[
-                "type",
-                "time",
-                "eventName",
-                "values",
-                "uid",
-                "sid",
-                "tokenId",
-                "orgId",
-                "traceId",
-                "unsafeParams",
-                "tags",
-            ],
-            Visitor_,
-        )
-    }
-}
-struct Visitor_;
-impl<'de> de::Visitor<'de> for Visitor_ {
-    type Value = EventLogV2;
-    fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.write_str("map")
-    }
-    fn visit_map<A>(self, mut map_: A) -> Result<EventLogV2, A::Error>
-    where
-        A: de::MapAccess<'de>,
-    {
-        let mut type_ = None;
-        let mut time = None;
-        let mut event_name = None;
-        let mut values = None;
-        let mut uid = None;
-        let mut sid = None;
-        let mut token_id = None;
-        let mut org_id = None;
-        let mut trace_id = None;
-        let mut unsafe_params = None;
-        let mut tags = None;
-        while let Some(field_) = map_.next_key()? {
-            match field_ {
-                Field_::Type => type_ = Some(map_.next_value()?),
-                Field_::Time => time = Some(map_.next_value()?),
-                Field_::EventName => event_name = Some(map_.next_value()?),
-                Field_::Values => values = Some(map_.next_value()?),
-                Field_::Uid => uid = Some(map_.next_value()?),
-                Field_::Sid => sid = Some(map_.next_value()?),
-                Field_::TokenId => token_id = Some(map_.next_value()?),
-                Field_::OrgId => org_id = Some(map_.next_value()?),
-                Field_::TraceId => trace_id = Some(map_.next_value()?),
-                Field_::UnsafeParams => unsafe_params = Some(map_.next_value()?),
-                Field_::Tags => tags = Some(map_.next_value()?),
-                Field_::Unknown_ => {
-                    map_.next_value::<de::IgnoredAny>()?;
-                }
-            }
-        }
-        let type_ = match type_ {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("type")),
-        };
-        let time = match time {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("time")),
-        };
-        let event_name = match event_name {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("eventName")),
-        };
-        let values = match values {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let uid = match uid {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let sid = match sid {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let token_id = match token_id {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let org_id = match org_id {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let trace_id = match trace_id {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let unsafe_params = match unsafe_params {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let tags = match tags {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        Ok(EventLogV2 {
-            type_,
-            time,
-            event_name,
-            values,
-            uid,
-            sid,
-            token_id,
-            org_id,
-            trace_id,
-            unsafe_params,
-            tags,
-        })
-    }
-}
-enum Field_ {
-    Type,
-    Time,
-    EventName,
-    Values,
-    Uid,
-    Sid,
-    TokenId,
-    OrgId,
-    TraceId,
-    UnsafeParams,
-    Tags,
-    Unknown_,
-}
-impl<'de> de::Deserialize<'de> for Field_ {
-    fn deserialize<D>(d: D) -> Result<Field_, D::Error>
-    where
-        D: de::Deserializer<'de>,
-    {
-        d.deserialize_str(FieldVisitor_)
-    }
-}
-struct FieldVisitor_;
-impl<'de> de::Visitor<'de> for FieldVisitor_ {
-    type Value = Field_;
-    fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.write_str("string")
-    }
-    fn visit_str<E>(self, value: &str) -> Result<Field_, E>
-    where
-        E: de::Error,
-    {
-        let v = match value {
-            "type" => Field_::Type,
-            "time" => Field_::Time,
-            "eventName" => Field_::EventName,
-            "values" => Field_::Values,
-            "uid" => Field_::Uid,
-            "sid" => Field_::Sid,
-            "tokenId" => Field_::TokenId,
-            "orgId" => Field_::OrgId,
-            "traceId" => Field_::TraceId,
-            "unsafeParams" => Field_::UnsafeParams,
-            "tags" => Field_::Tags,
-            _ => Field_::Unknown_,
-        };
-        Ok(v)
     }
 }

--- a/witchcraft-server/src/logging/api/generic_diagnostic.rs
+++ b/witchcraft-server/src/logging/api/generic_diagnostic.rs
@@ -1,11 +1,20 @@
-use conjure_object::serde::{ser, de};
-use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use std::fmt;
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+    Debug,
+    Clone,
+    conjure_object::serde::Serialize,
+    conjure_object::serde::Deserialize,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash
+)]
+#[serde(crate = "conjure_object::serde")]
 #[conjure_object::private::staged_builder::staged_builder]
 #[builder(crate = conjure_object::private::staged_builder, update, inline)]
 pub struct GenericDiagnostic {
     #[builder(into)]
+    #[serde(rename = "diagnosticType")]
     diagnostic_type: String,
     #[builder(
         custom(
@@ -14,6 +23,7 @@ pub struct GenericDiagnostic {
             convert = |v|conjure_object::Any::new(v).expect("value failed to serialize")
         )
     )]
+    #[serde(rename = "value")]
     value: conjure_object::Any,
 }
 impl GenericDiagnostic {
@@ -34,91 +44,5 @@ impl GenericDiagnostic {
     #[inline]
     pub fn value(&self) -> &conjure_object::Any {
         &self.value
-    }
-}
-impl ser::Serialize for GenericDiagnostic {
-    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
-    where
-        S: ser::Serializer,
-    {
-        let size = 2usize;
-        let mut s = s.serialize_struct("GenericDiagnostic", size)?;
-        s.serialize_field("diagnosticType", &self.diagnostic_type)?;
-        s.serialize_field("value", &self.value)?;
-        s.end()
-    }
-}
-impl<'de> de::Deserialize<'de> for GenericDiagnostic {
-    fn deserialize<D>(d: D) -> Result<GenericDiagnostic, D::Error>
-    where
-        D: de::Deserializer<'de>,
-    {
-        d.deserialize_struct("GenericDiagnostic", &["diagnosticType", "value"], Visitor_)
-    }
-}
-struct Visitor_;
-impl<'de> de::Visitor<'de> for Visitor_ {
-    type Value = GenericDiagnostic;
-    fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.write_str("map")
-    }
-    fn visit_map<A>(self, mut map_: A) -> Result<GenericDiagnostic, A::Error>
-    where
-        A: de::MapAccess<'de>,
-    {
-        let mut diagnostic_type = None;
-        let mut value = None;
-        while let Some(field_) = map_.next_key()? {
-            match field_ {
-                Field_::DiagnosticType => diagnostic_type = Some(map_.next_value()?),
-                Field_::Value => value = Some(map_.next_value()?),
-                Field_::Unknown_ => {
-                    map_.next_value::<de::IgnoredAny>()?;
-                }
-            }
-        }
-        let diagnostic_type = match diagnostic_type {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("diagnosticType")),
-        };
-        let value = match value {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("value")),
-        };
-        Ok(GenericDiagnostic {
-            diagnostic_type,
-            value,
-        })
-    }
-}
-enum Field_ {
-    DiagnosticType,
-    Value,
-    Unknown_,
-}
-impl<'de> de::Deserialize<'de> for Field_ {
-    fn deserialize<D>(d: D) -> Result<Field_, D::Error>
-    where
-        D: de::Deserializer<'de>,
-    {
-        d.deserialize_str(FieldVisitor_)
-    }
-}
-struct FieldVisitor_;
-impl<'de> de::Visitor<'de> for FieldVisitor_ {
-    type Value = Field_;
-    fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.write_str("string")
-    }
-    fn visit_str<E>(self, value: &str) -> Result<Field_, E>
-    where
-        E: de::Error,
-    {
-        let v = match value {
-            "diagnosticType" => Field_::DiagnosticType,
-            "value" => Field_::Value,
-            _ => Field_::Unknown_,
-        };
-        Ok(v)
     }
 }

--- a/witchcraft-server/src/logging/api/log_level.rs
+++ b/witchcraft-server/src/logging/api/log_level.rs
@@ -1,13 +1,30 @@
-use conjure_object::serde::{ser, de};
+#![allow(deprecated)]
 use std::fmt;
 use std::str;
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum LogLevel {
-    Fatal,
-    Error,
-    Warn,
-    Info,
+#[derive(
     Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    conjure_object::serde::Deserialize,
+    conjure_object::serde::Serialize,
+)]
+#[serde(crate = "conjure_object::serde")]
+pub enum LogLevel {
+    #[serde(rename = "FATAL")]
+    Fatal,
+    #[serde(rename = "ERROR")]
+    Error,
+    #[serde(rename = "WARN")]
+    Warn,
+    #[serde(rename = "INFO")]
+    Info,
+    #[serde(rename = "DEBUG")]
+    Debug,
+    #[serde(rename = "TRACE")]
     Trace,
 }
 impl LogLevel {
@@ -54,44 +71,5 @@ impl conjure_object::FromPlain for LogLevel {
     #[inline]
     fn from_plain(v: &str) -> Result<LogLevel, conjure_object::plain::ParseEnumError> {
         v.parse()
-    }
-}
-impl ser::Serialize for LogLevel {
-    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
-    where
-        S: ser::Serializer,
-    {
-        s.serialize_str(self.as_str())
-    }
-}
-impl<'de> de::Deserialize<'de> for LogLevel {
-    fn deserialize<D>(d: D) -> Result<LogLevel, D::Error>
-    where
-        D: de::Deserializer<'de>,
-    {
-        d.deserialize_str(Visitor_)
-    }
-}
-struct Visitor_;
-impl<'de> de::Visitor<'de> for Visitor_ {
-    type Value = LogLevel;
-    fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.write_str("a string")
-    }
-    fn visit_str<E>(self, v: &str) -> Result<LogLevel, E>
-    where
-        E: de::Error,
-    {
-        match v.parse() {
-            Ok(e) => Ok(e),
-            Err(_) => {
-                Err(
-                    de::Error::unknown_variant(
-                        v,
-                        &["FATAL", "ERROR", "WARN", "INFO", "DEBUG", "TRACE"],
-                    ),
-                )
-            }
-        }
     }
 }

--- a/witchcraft-server/src/logging/api/metric_log_v1.rs
+++ b/witchcraft-server/src/logging/api/metric_log_v1.rs
@@ -1,17 +1,29 @@
-use conjure_object::serde::{ser, de};
-use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use std::fmt;
 ///Definition of the metric.1 format.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+    Debug,
+    Clone,
+    conjure_object::serde::Serialize,
+    conjure_object::serde::Deserialize,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash
+)]
+#[serde(crate = "conjure_object::serde")]
 #[conjure_object::private::staged_builder::staged_builder]
 #[builder(crate = conjure_object::private::staged_builder, update, inline)]
 pub struct MetricLogV1 {
     #[builder(into)]
+    #[serde(rename = "type")]
     type_: String,
+    #[serde(rename = "time")]
     time: conjure_object::DateTime<conjure_object::Utc>,
     #[builder(into)]
+    #[serde(rename = "metricName")]
     metric_name: String,
     #[builder(into)]
+    #[serde(rename = "metricType")]
     metric_type: String,
     #[builder(
         default,
@@ -28,16 +40,30 @@ pub struct MetricLogV1 {
             )
         )
     )]
+    #[serde(
+        rename = "values",
+        skip_serializing_if = "std::collections::BTreeMap::is_empty",
+        default
+    )]
     values: std::collections::BTreeMap<String, conjure_object::Any>,
     #[builder(default, map(key(type = String, into), value(type = String, into)))]
+    #[serde(
+        rename = "tags",
+        skip_serializing_if = "std::collections::BTreeMap::is_empty",
+        default
+    )]
     tags: std::collections::BTreeMap<String, String>,
     #[builder(default, into)]
+    #[serde(rename = "uid", skip_serializing_if = "Option::is_none", default)]
     uid: Option<super::UserId>,
     #[builder(default, into)]
+    #[serde(rename = "sid", skip_serializing_if = "Option::is_none", default)]
     sid: Option<super::SessionId>,
     #[builder(default, into)]
+    #[serde(rename = "tokenId", skip_serializing_if = "Option::is_none", default)]
     token_id: Option<super::TokenId>,
     #[builder(default, into)]
+    #[serde(rename = "orgId", skip_serializing_if = "Option::is_none", default)]
     org_id: Option<super::OrganizationId>,
     #[builder(
         default,
@@ -53,6 +79,11 @@ pub struct MetricLogV1 {
                 )
             )
         )
+    )]
+    #[serde(
+        rename = "unsafeParams",
+        skip_serializing_if = "std::collections::BTreeMap::is_empty",
+        default
     )]
     unsafe_params: std::collections::BTreeMap<String, conjure_object::Any>,
 }
@@ -111,253 +142,5 @@ impl MetricLogV1 {
         &self,
     ) -> &std::collections::BTreeMap<String, conjure_object::Any> {
         &self.unsafe_params
-    }
-}
-impl ser::Serialize for MetricLogV1 {
-    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
-    where
-        S: ser::Serializer,
-    {
-        let mut size = 4usize;
-        let skip_values = self.values.is_empty();
-        if !skip_values {
-            size += 1;
-        }
-        let skip_tags = self.tags.is_empty();
-        if !skip_tags {
-            size += 1;
-        }
-        let skip_uid = self.uid.is_none();
-        if !skip_uid {
-            size += 1;
-        }
-        let skip_sid = self.sid.is_none();
-        if !skip_sid {
-            size += 1;
-        }
-        let skip_token_id = self.token_id.is_none();
-        if !skip_token_id {
-            size += 1;
-        }
-        let skip_org_id = self.org_id.is_none();
-        if !skip_org_id {
-            size += 1;
-        }
-        let skip_unsafe_params = self.unsafe_params.is_empty();
-        if !skip_unsafe_params {
-            size += 1;
-        }
-        let mut s = s.serialize_struct("MetricLogV1", size)?;
-        s.serialize_field("type", &self.type_)?;
-        s.serialize_field("time", &self.time)?;
-        s.serialize_field("metricName", &self.metric_name)?;
-        s.serialize_field("metricType", &self.metric_type)?;
-        if skip_values {
-            s.skip_field("values")?;
-        } else {
-            s.serialize_field("values", &self.values)?;
-        }
-        if skip_tags {
-            s.skip_field("tags")?;
-        } else {
-            s.serialize_field("tags", &self.tags)?;
-        }
-        if skip_uid {
-            s.skip_field("uid")?;
-        } else {
-            s.serialize_field("uid", &self.uid)?;
-        }
-        if skip_sid {
-            s.skip_field("sid")?;
-        } else {
-            s.serialize_field("sid", &self.sid)?;
-        }
-        if skip_token_id {
-            s.skip_field("tokenId")?;
-        } else {
-            s.serialize_field("tokenId", &self.token_id)?;
-        }
-        if skip_org_id {
-            s.skip_field("orgId")?;
-        } else {
-            s.serialize_field("orgId", &self.org_id)?;
-        }
-        if skip_unsafe_params {
-            s.skip_field("unsafeParams")?;
-        } else {
-            s.serialize_field("unsafeParams", &self.unsafe_params)?;
-        }
-        s.end()
-    }
-}
-impl<'de> de::Deserialize<'de> for MetricLogV1 {
-    fn deserialize<D>(d: D) -> Result<MetricLogV1, D::Error>
-    where
-        D: de::Deserializer<'de>,
-    {
-        d.deserialize_struct(
-            "MetricLogV1",
-            &[
-                "type",
-                "time",
-                "metricName",
-                "metricType",
-                "values",
-                "tags",
-                "uid",
-                "sid",
-                "tokenId",
-                "orgId",
-                "unsafeParams",
-            ],
-            Visitor_,
-        )
-    }
-}
-struct Visitor_;
-impl<'de> de::Visitor<'de> for Visitor_ {
-    type Value = MetricLogV1;
-    fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.write_str("map")
-    }
-    fn visit_map<A>(self, mut map_: A) -> Result<MetricLogV1, A::Error>
-    where
-        A: de::MapAccess<'de>,
-    {
-        let mut type_ = None;
-        let mut time = None;
-        let mut metric_name = None;
-        let mut metric_type = None;
-        let mut values = None;
-        let mut tags = None;
-        let mut uid = None;
-        let mut sid = None;
-        let mut token_id = None;
-        let mut org_id = None;
-        let mut unsafe_params = None;
-        while let Some(field_) = map_.next_key()? {
-            match field_ {
-                Field_::Type => type_ = Some(map_.next_value()?),
-                Field_::Time => time = Some(map_.next_value()?),
-                Field_::MetricName => metric_name = Some(map_.next_value()?),
-                Field_::MetricType => metric_type = Some(map_.next_value()?),
-                Field_::Values => values = Some(map_.next_value()?),
-                Field_::Tags => tags = Some(map_.next_value()?),
-                Field_::Uid => uid = Some(map_.next_value()?),
-                Field_::Sid => sid = Some(map_.next_value()?),
-                Field_::TokenId => token_id = Some(map_.next_value()?),
-                Field_::OrgId => org_id = Some(map_.next_value()?),
-                Field_::UnsafeParams => unsafe_params = Some(map_.next_value()?),
-                Field_::Unknown_ => {
-                    map_.next_value::<de::IgnoredAny>()?;
-                }
-            }
-        }
-        let type_ = match type_ {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("type")),
-        };
-        let time = match time {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("time")),
-        };
-        let metric_name = match metric_name {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("metricName")),
-        };
-        let metric_type = match metric_type {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("metricType")),
-        };
-        let values = match values {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let tags = match tags {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let uid = match uid {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let sid = match sid {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let token_id = match token_id {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let org_id = match org_id {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let unsafe_params = match unsafe_params {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        Ok(MetricLogV1 {
-            type_,
-            time,
-            metric_name,
-            metric_type,
-            values,
-            tags,
-            uid,
-            sid,
-            token_id,
-            org_id,
-            unsafe_params,
-        })
-    }
-}
-enum Field_ {
-    Type,
-    Time,
-    MetricName,
-    MetricType,
-    Values,
-    Tags,
-    Uid,
-    Sid,
-    TokenId,
-    OrgId,
-    UnsafeParams,
-    Unknown_,
-}
-impl<'de> de::Deserialize<'de> for Field_ {
-    fn deserialize<D>(d: D) -> Result<Field_, D::Error>
-    where
-        D: de::Deserializer<'de>,
-    {
-        d.deserialize_str(FieldVisitor_)
-    }
-}
-struct FieldVisitor_;
-impl<'de> de::Visitor<'de> for FieldVisitor_ {
-    type Value = Field_;
-    fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.write_str("string")
-    }
-    fn visit_str<E>(self, value: &str) -> Result<Field_, E>
-    where
-        E: de::Error,
-    {
-        let v = match value {
-            "type" => Field_::Type,
-            "time" => Field_::Time,
-            "metricName" => Field_::MetricName,
-            "metricType" => Field_::MetricType,
-            "values" => Field_::Values,
-            "tags" => Field_::Tags,
-            "uid" => Field_::Uid,
-            "sid" => Field_::Sid,
-            "tokenId" => Field_::TokenId,
-            "orgId" => Field_::OrgId,
-            "unsafeParams" => Field_::UnsafeParams,
-            _ => Field_::Unknown_,
-        };
-        Ok(v)
     }
 }

--- a/witchcraft-server/src/logging/api/organization.rs
+++ b/witchcraft-server/src/logging/api/organization.rs
@@ -1,13 +1,23 @@
-use conjure_object::serde::{ser, de};
-use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use std::fmt;
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+    Debug,
+    Clone,
+    conjure_object::serde::Serialize,
+    conjure_object::serde::Deserialize,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash
+)]
+#[serde(crate = "conjure_object::serde")]
 #[conjure_object::private::staged_builder::staged_builder]
 #[builder(crate = conjure_object::private::staged_builder, update, inline)]
 pub struct Organization {
     #[builder(into)]
+    #[serde(rename = "id")]
     id: String,
     #[builder(into)]
+    #[serde(rename = "reason")]
     reason: String,
 }
 impl Organization {
@@ -25,88 +35,5 @@ impl Organization {
     #[inline]
     pub fn reason(&self) -> &str {
         &*self.reason
-    }
-}
-impl ser::Serialize for Organization {
-    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
-    where
-        S: ser::Serializer,
-    {
-        let size = 2usize;
-        let mut s = s.serialize_struct("Organization", size)?;
-        s.serialize_field("id", &self.id)?;
-        s.serialize_field("reason", &self.reason)?;
-        s.end()
-    }
-}
-impl<'de> de::Deserialize<'de> for Organization {
-    fn deserialize<D>(d: D) -> Result<Organization, D::Error>
-    where
-        D: de::Deserializer<'de>,
-    {
-        d.deserialize_struct("Organization", &["id", "reason"], Visitor_)
-    }
-}
-struct Visitor_;
-impl<'de> de::Visitor<'de> for Visitor_ {
-    type Value = Organization;
-    fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.write_str("map")
-    }
-    fn visit_map<A>(self, mut map_: A) -> Result<Organization, A::Error>
-    where
-        A: de::MapAccess<'de>,
-    {
-        let mut id = None;
-        let mut reason = None;
-        while let Some(field_) = map_.next_key()? {
-            match field_ {
-                Field_::Id => id = Some(map_.next_value()?),
-                Field_::Reason => reason = Some(map_.next_value()?),
-                Field_::Unknown_ => {
-                    map_.next_value::<de::IgnoredAny>()?;
-                }
-            }
-        }
-        let id = match id {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("id")),
-        };
-        let reason = match reason {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("reason")),
-        };
-        Ok(Organization { id, reason })
-    }
-}
-enum Field_ {
-    Id,
-    Reason,
-    Unknown_,
-}
-impl<'de> de::Deserialize<'de> for Field_ {
-    fn deserialize<D>(d: D) -> Result<Field_, D::Error>
-    where
-        D: de::Deserializer<'de>,
-    {
-        d.deserialize_str(FieldVisitor_)
-    }
-}
-struct FieldVisitor_;
-impl<'de> de::Visitor<'de> for FieldVisitor_ {
-    type Value = Field_;
-    fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.write_str("string")
-    }
-    fn visit_str<E>(self, value: &str) -> Result<Field_, E>
-    where
-        E: de::Error,
-    {
-        let v = match value {
-            "id" => Field_::Id,
-            "reason" => Field_::Reason,
-            _ => Field_::Unknown_,
-        };
-        Ok(v)
     }
 }

--- a/witchcraft-server/src/logging/api/organization_id.rs
+++ b/witchcraft-server/src/logging/api/organization_id.rs
@@ -1,5 +1,16 @@
-use conjure_object::serde::{ser, de};
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[derive(
+    Debug,
+    Clone,
+    conjure_object::serde::Deserialize,
+    conjure_object::serde::Serialize,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Default
+)]
+#[serde(crate = "conjure_object::serde", transparent)]
 pub struct OrganizationId(pub String);
 impl std::fmt::Display for OrganizationId {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -35,21 +46,5 @@ impl std::ops::DerefMut for OrganizationId {
     #[inline]
     fn deref_mut(&mut self) -> &mut String {
         &mut self.0
-    }
-}
-impl ser::Serialize for OrganizationId {
-    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
-    where
-        S: ser::Serializer,
-    {
-        self.0.serialize(s)
-    }
-}
-impl<'de> de::Deserialize<'de> for OrganizationId {
-    fn deserialize<D>(d: D) -> Result<OrganizationId, D::Error>
-    where
-        D: de::Deserializer<'de>,
-    {
-        de::Deserialize::deserialize(d).map(OrganizationId)
     }
 }

--- a/witchcraft-server/src/logging/api/request_log_v1.rs
+++ b/witchcraft-server/src/logging/api/request_log_v1.rs
@@ -1,19 +1,32 @@
-use conjure_object::serde::{ser, de};
-use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use std::fmt;
 ///Definition of the request.1 format.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+    Debug,
+    Clone,
+    conjure_object::serde::Serialize,
+    conjure_object::serde::Deserialize,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash
+)]
+#[serde(crate = "conjure_object::serde")]
 #[conjure_object::private::staged_builder::staged_builder]
 #[builder(crate = conjure_object::private::staged_builder, update, inline)]
 pub struct RequestLogV1 {
     #[builder(into)]
+    #[serde(rename = "type")]
     type_: String,
+    #[serde(rename = "time")]
     time: conjure_object::DateTime<conjure_object::Utc>,
     #[builder(default, into)]
+    #[serde(rename = "method", skip_serializing_if = "Option::is_none", default)]
     method: Option<String>,
     #[builder(into)]
+    #[serde(rename = "protocol")]
     protocol: String,
     #[builder(into)]
+    #[serde(rename = "path")]
     path: String,
     #[builder(
         default,
@@ -29,6 +42,11 @@ pub struct RequestLogV1 {
                 )
             )
         )
+    )]
+    #[serde(
+        rename = "pathParams",
+        skip_serializing_if = "std::collections::BTreeMap::is_empty",
+        default
     )]
     path_params: std::collections::BTreeMap<String, conjure_object::Any>,
     #[builder(
@@ -46,6 +64,11 @@ pub struct RequestLogV1 {
             )
         )
     )]
+    #[serde(
+        rename = "queryParams",
+        skip_serializing_if = "std::collections::BTreeMap::is_empty",
+        default
+    )]
     query_params: std::collections::BTreeMap<String, conjure_object::Any>,
     #[builder(
         default,
@@ -61,6 +84,11 @@ pub struct RequestLogV1 {
                 )
             )
         )
+    )]
+    #[serde(
+        rename = "headerParams",
+        skip_serializing_if = "std::collections::BTreeMap::is_empty",
+        default
     )]
     header_params: std::collections::BTreeMap<String, conjure_object::Any>,
     #[builder(
@@ -78,22 +106,36 @@ pub struct RequestLogV1 {
             )
         )
     )]
+    #[serde(
+        rename = "bodyParams",
+        skip_serializing_if = "std::collections::BTreeMap::is_empty",
+        default
+    )]
     body_params: std::collections::BTreeMap<String, conjure_object::Any>,
+    #[serde(rename = "status")]
     status: i32,
     #[builder(into)]
+    #[serde(rename = "requestSize")]
     request_size: String,
     #[builder(into)]
+    #[serde(rename = "responseSize")]
     response_size: String,
+    #[serde(rename = "duration")]
     duration: i32,
     #[builder(default, into)]
+    #[serde(rename = "uid", skip_serializing_if = "Option::is_none", default)]
     uid: Option<super::UserId>,
     #[builder(default, into)]
+    #[serde(rename = "sid", skip_serializing_if = "Option::is_none", default)]
     sid: Option<super::SessionId>,
     #[builder(default, into)]
+    #[serde(rename = "tokenId", skip_serializing_if = "Option::is_none", default)]
     token_id: Option<super::TokenId>,
     #[builder(default, into)]
+    #[serde(rename = "orgId", skip_serializing_if = "Option::is_none", default)]
     org_id: Option<super::OrganizationId>,
     #[builder(default, into)]
+    #[serde(rename = "traceId", skip_serializing_if = "Option::is_none", default)]
     trace_id: Option<super::TraceId>,
     #[builder(
         default,
@@ -109,6 +151,11 @@ pub struct RequestLogV1 {
                 )
             )
         )
+    )]
+    #[serde(
+        rename = "unsafeParams",
+        skip_serializing_if = "std::collections::BTreeMap::is_empty",
+        default
     )]
     unsafe_params: std::collections::BTreeMap<String, conjure_object::Any>,
 }
@@ -215,373 +262,5 @@ impl RequestLogV1 {
         &self,
     ) -> &std::collections::BTreeMap<String, conjure_object::Any> {
         &self.unsafe_params
-    }
-}
-impl ser::Serialize for RequestLogV1 {
-    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
-    where
-        S: ser::Serializer,
-    {
-        let mut size = 8usize;
-        let skip_method = self.method.is_none();
-        if !skip_method {
-            size += 1;
-        }
-        let skip_path_params = self.path_params.is_empty();
-        if !skip_path_params {
-            size += 1;
-        }
-        let skip_query_params = self.query_params.is_empty();
-        if !skip_query_params {
-            size += 1;
-        }
-        let skip_header_params = self.header_params.is_empty();
-        if !skip_header_params {
-            size += 1;
-        }
-        let skip_body_params = self.body_params.is_empty();
-        if !skip_body_params {
-            size += 1;
-        }
-        let skip_uid = self.uid.is_none();
-        if !skip_uid {
-            size += 1;
-        }
-        let skip_sid = self.sid.is_none();
-        if !skip_sid {
-            size += 1;
-        }
-        let skip_token_id = self.token_id.is_none();
-        if !skip_token_id {
-            size += 1;
-        }
-        let skip_org_id = self.org_id.is_none();
-        if !skip_org_id {
-            size += 1;
-        }
-        let skip_trace_id = self.trace_id.is_none();
-        if !skip_trace_id {
-            size += 1;
-        }
-        let skip_unsafe_params = self.unsafe_params.is_empty();
-        if !skip_unsafe_params {
-            size += 1;
-        }
-        let mut s = s.serialize_struct("RequestLogV1", size)?;
-        s.serialize_field("type", &self.type_)?;
-        s.serialize_field("time", &self.time)?;
-        if skip_method {
-            s.skip_field("method")?;
-        } else {
-            s.serialize_field("method", &self.method)?;
-        }
-        s.serialize_field("protocol", &self.protocol)?;
-        s.serialize_field("path", &self.path)?;
-        if skip_path_params {
-            s.skip_field("pathParams")?;
-        } else {
-            s.serialize_field("pathParams", &self.path_params)?;
-        }
-        if skip_query_params {
-            s.skip_field("queryParams")?;
-        } else {
-            s.serialize_field("queryParams", &self.query_params)?;
-        }
-        if skip_header_params {
-            s.skip_field("headerParams")?;
-        } else {
-            s.serialize_field("headerParams", &self.header_params)?;
-        }
-        if skip_body_params {
-            s.skip_field("bodyParams")?;
-        } else {
-            s.serialize_field("bodyParams", &self.body_params)?;
-        }
-        s.serialize_field("status", &self.status)?;
-        s.serialize_field("requestSize", &self.request_size)?;
-        s.serialize_field("responseSize", &self.response_size)?;
-        s.serialize_field("duration", &self.duration)?;
-        if skip_uid {
-            s.skip_field("uid")?;
-        } else {
-            s.serialize_field("uid", &self.uid)?;
-        }
-        if skip_sid {
-            s.skip_field("sid")?;
-        } else {
-            s.serialize_field("sid", &self.sid)?;
-        }
-        if skip_token_id {
-            s.skip_field("tokenId")?;
-        } else {
-            s.serialize_field("tokenId", &self.token_id)?;
-        }
-        if skip_org_id {
-            s.skip_field("orgId")?;
-        } else {
-            s.serialize_field("orgId", &self.org_id)?;
-        }
-        if skip_trace_id {
-            s.skip_field("traceId")?;
-        } else {
-            s.serialize_field("traceId", &self.trace_id)?;
-        }
-        if skip_unsafe_params {
-            s.skip_field("unsafeParams")?;
-        } else {
-            s.serialize_field("unsafeParams", &self.unsafe_params)?;
-        }
-        s.end()
-    }
-}
-impl<'de> de::Deserialize<'de> for RequestLogV1 {
-    fn deserialize<D>(d: D) -> Result<RequestLogV1, D::Error>
-    where
-        D: de::Deserializer<'de>,
-    {
-        d.deserialize_struct(
-            "RequestLogV1",
-            &[
-                "type",
-                "time",
-                "method",
-                "protocol",
-                "path",
-                "pathParams",
-                "queryParams",
-                "headerParams",
-                "bodyParams",
-                "status",
-                "requestSize",
-                "responseSize",
-                "duration",
-                "uid",
-                "sid",
-                "tokenId",
-                "orgId",
-                "traceId",
-                "unsafeParams",
-            ],
-            Visitor_,
-        )
-    }
-}
-struct Visitor_;
-impl<'de> de::Visitor<'de> for Visitor_ {
-    type Value = RequestLogV1;
-    fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.write_str("map")
-    }
-    fn visit_map<A>(self, mut map_: A) -> Result<RequestLogV1, A::Error>
-    where
-        A: de::MapAccess<'de>,
-    {
-        let mut type_ = None;
-        let mut time = None;
-        let mut method = None;
-        let mut protocol = None;
-        let mut path = None;
-        let mut path_params = None;
-        let mut query_params = None;
-        let mut header_params = None;
-        let mut body_params = None;
-        let mut status = None;
-        let mut request_size = None;
-        let mut response_size = None;
-        let mut duration = None;
-        let mut uid = None;
-        let mut sid = None;
-        let mut token_id = None;
-        let mut org_id = None;
-        let mut trace_id = None;
-        let mut unsafe_params = None;
-        while let Some(field_) = map_.next_key()? {
-            match field_ {
-                Field_::Type => type_ = Some(map_.next_value()?),
-                Field_::Time => time = Some(map_.next_value()?),
-                Field_::Method => method = Some(map_.next_value()?),
-                Field_::Protocol => protocol = Some(map_.next_value()?),
-                Field_::Path => path = Some(map_.next_value()?),
-                Field_::PathParams => path_params = Some(map_.next_value()?),
-                Field_::QueryParams => query_params = Some(map_.next_value()?),
-                Field_::HeaderParams => header_params = Some(map_.next_value()?),
-                Field_::BodyParams => body_params = Some(map_.next_value()?),
-                Field_::Status => status = Some(map_.next_value()?),
-                Field_::RequestSize => request_size = Some(map_.next_value()?),
-                Field_::ResponseSize => response_size = Some(map_.next_value()?),
-                Field_::Duration => duration = Some(map_.next_value()?),
-                Field_::Uid => uid = Some(map_.next_value()?),
-                Field_::Sid => sid = Some(map_.next_value()?),
-                Field_::TokenId => token_id = Some(map_.next_value()?),
-                Field_::OrgId => org_id = Some(map_.next_value()?),
-                Field_::TraceId => trace_id = Some(map_.next_value()?),
-                Field_::UnsafeParams => unsafe_params = Some(map_.next_value()?),
-                Field_::Unknown_ => {
-                    map_.next_value::<de::IgnoredAny>()?;
-                }
-            }
-        }
-        let type_ = match type_ {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("type")),
-        };
-        let time = match time {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("time")),
-        };
-        let method = match method {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let protocol = match protocol {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("protocol")),
-        };
-        let path = match path {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("path")),
-        };
-        let path_params = match path_params {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let query_params = match query_params {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let header_params = match header_params {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let body_params = match body_params {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let status = match status {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("status")),
-        };
-        let request_size = match request_size {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("requestSize")),
-        };
-        let response_size = match response_size {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("responseSize")),
-        };
-        let duration = match duration {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("duration")),
-        };
-        let uid = match uid {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let sid = match sid {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let token_id = match token_id {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let org_id = match org_id {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let trace_id = match trace_id {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let unsafe_params = match unsafe_params {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        Ok(RequestLogV1 {
-            type_,
-            time,
-            method,
-            protocol,
-            path,
-            path_params,
-            query_params,
-            header_params,
-            body_params,
-            status,
-            request_size,
-            response_size,
-            duration,
-            uid,
-            sid,
-            token_id,
-            org_id,
-            trace_id,
-            unsafe_params,
-        })
-    }
-}
-enum Field_ {
-    Type,
-    Time,
-    Method,
-    Protocol,
-    Path,
-    PathParams,
-    QueryParams,
-    HeaderParams,
-    BodyParams,
-    Status,
-    RequestSize,
-    ResponseSize,
-    Duration,
-    Uid,
-    Sid,
-    TokenId,
-    OrgId,
-    TraceId,
-    UnsafeParams,
-    Unknown_,
-}
-impl<'de> de::Deserialize<'de> for Field_ {
-    fn deserialize<D>(d: D) -> Result<Field_, D::Error>
-    where
-        D: de::Deserializer<'de>,
-    {
-        d.deserialize_str(FieldVisitor_)
-    }
-}
-struct FieldVisitor_;
-impl<'de> de::Visitor<'de> for FieldVisitor_ {
-    type Value = Field_;
-    fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.write_str("string")
-    }
-    fn visit_str<E>(self, value: &str) -> Result<Field_, E>
-    where
-        E: de::Error,
-    {
-        let v = match value {
-            "type" => Field_::Type,
-            "time" => Field_::Time,
-            "method" => Field_::Method,
-            "protocol" => Field_::Protocol,
-            "path" => Field_::Path,
-            "pathParams" => Field_::PathParams,
-            "queryParams" => Field_::QueryParams,
-            "headerParams" => Field_::HeaderParams,
-            "bodyParams" => Field_::BodyParams,
-            "status" => Field_::Status,
-            "requestSize" => Field_::RequestSize,
-            "responseSize" => Field_::ResponseSize,
-            "duration" => Field_::Duration,
-            "uid" => Field_::Uid,
-            "sid" => Field_::Sid,
-            "tokenId" => Field_::TokenId,
-            "orgId" => Field_::OrgId,
-            "traceId" => Field_::TraceId,
-            "unsafeParams" => Field_::UnsafeParams,
-            _ => Field_::Unknown_,
-        };
-        Ok(v)
     }
 }

--- a/witchcraft-server/src/logging/api/request_log_v2.rs
+++ b/witchcraft-server/src/logging/api/request_log_v2.rs
@@ -1,19 +1,32 @@
-use conjure_object::serde::{ser, de};
-use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use std::fmt;
 ///Definition of the request.2 format.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+    Debug,
+    Clone,
+    conjure_object::serde::Serialize,
+    conjure_object::serde::Deserialize,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash
+)]
+#[serde(crate = "conjure_object::serde")]
 #[conjure_object::private::staged_builder::staged_builder]
 #[builder(crate = conjure_object::private::staged_builder, update, inline)]
 pub struct RequestLogV2 {
     #[builder(into)]
+    #[serde(rename = "type")]
     type_: String,
+    #[serde(rename = "time")]
     time: conjure_object::DateTime<conjure_object::Utc>,
     #[builder(default, into)]
+    #[serde(rename = "method", skip_serializing_if = "Option::is_none", default)]
     method: Option<String>,
     #[builder(into)]
+    #[serde(rename = "protocol")]
     protocol: String,
     #[builder(into)]
+    #[serde(rename = "path")]
     path: String,
     #[builder(
         default,
@@ -30,20 +43,34 @@ pub struct RequestLogV2 {
             )
         )
     )]
+    #[serde(
+        rename = "params",
+        skip_serializing_if = "std::collections::BTreeMap::is_empty",
+        default
+    )]
     params: std::collections::BTreeMap<String, conjure_object::Any>,
+    #[serde(rename = "status")]
     status: i32,
+    #[serde(rename = "requestSize")]
     request_size: conjure_object::SafeLong,
+    #[serde(rename = "responseSize")]
     response_size: conjure_object::SafeLong,
+    #[serde(rename = "duration")]
     duration: conjure_object::SafeLong,
     #[builder(default, into)]
+    #[serde(rename = "uid", skip_serializing_if = "Option::is_none", default)]
     uid: Option<super::UserId>,
     #[builder(default, into)]
+    #[serde(rename = "sid", skip_serializing_if = "Option::is_none", default)]
     sid: Option<super::SessionId>,
     #[builder(default, into)]
+    #[serde(rename = "tokenId", skip_serializing_if = "Option::is_none", default)]
     token_id: Option<super::TokenId>,
     #[builder(default, into)]
+    #[serde(rename = "orgId", skip_serializing_if = "Option::is_none", default)]
     org_id: Option<super::OrganizationId>,
     #[builder(default, into)]
+    #[serde(rename = "traceId", skip_serializing_if = "Option::is_none", default)]
     trace_id: Option<super::TraceId>,
     #[builder(
         default,
@@ -59,6 +86,11 @@ pub struct RequestLogV2 {
                 )
             )
         )
+    )]
+    #[serde(
+        rename = "unsafeParams",
+        skip_serializing_if = "std::collections::BTreeMap::is_empty",
+        default
     )]
     unsafe_params: std::collections::BTreeMap<String, conjure_object::Any>,
 }
@@ -142,316 +174,5 @@ impl RequestLogV2 {
         &self,
     ) -> &std::collections::BTreeMap<String, conjure_object::Any> {
         &self.unsafe_params
-    }
-}
-impl ser::Serialize for RequestLogV2 {
-    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
-    where
-        S: ser::Serializer,
-    {
-        let mut size = 8usize;
-        let skip_method = self.method.is_none();
-        if !skip_method {
-            size += 1;
-        }
-        let skip_params = self.params.is_empty();
-        if !skip_params {
-            size += 1;
-        }
-        let skip_uid = self.uid.is_none();
-        if !skip_uid {
-            size += 1;
-        }
-        let skip_sid = self.sid.is_none();
-        if !skip_sid {
-            size += 1;
-        }
-        let skip_token_id = self.token_id.is_none();
-        if !skip_token_id {
-            size += 1;
-        }
-        let skip_org_id = self.org_id.is_none();
-        if !skip_org_id {
-            size += 1;
-        }
-        let skip_trace_id = self.trace_id.is_none();
-        if !skip_trace_id {
-            size += 1;
-        }
-        let skip_unsafe_params = self.unsafe_params.is_empty();
-        if !skip_unsafe_params {
-            size += 1;
-        }
-        let mut s = s.serialize_struct("RequestLogV2", size)?;
-        s.serialize_field("type", &self.type_)?;
-        s.serialize_field("time", &self.time)?;
-        if skip_method {
-            s.skip_field("method")?;
-        } else {
-            s.serialize_field("method", &self.method)?;
-        }
-        s.serialize_field("protocol", &self.protocol)?;
-        s.serialize_field("path", &self.path)?;
-        if skip_params {
-            s.skip_field("params")?;
-        } else {
-            s.serialize_field("params", &self.params)?;
-        }
-        s.serialize_field("status", &self.status)?;
-        s.serialize_field("requestSize", &self.request_size)?;
-        s.serialize_field("responseSize", &self.response_size)?;
-        s.serialize_field("duration", &self.duration)?;
-        if skip_uid {
-            s.skip_field("uid")?;
-        } else {
-            s.serialize_field("uid", &self.uid)?;
-        }
-        if skip_sid {
-            s.skip_field("sid")?;
-        } else {
-            s.serialize_field("sid", &self.sid)?;
-        }
-        if skip_token_id {
-            s.skip_field("tokenId")?;
-        } else {
-            s.serialize_field("tokenId", &self.token_id)?;
-        }
-        if skip_org_id {
-            s.skip_field("orgId")?;
-        } else {
-            s.serialize_field("orgId", &self.org_id)?;
-        }
-        if skip_trace_id {
-            s.skip_field("traceId")?;
-        } else {
-            s.serialize_field("traceId", &self.trace_id)?;
-        }
-        if skip_unsafe_params {
-            s.skip_field("unsafeParams")?;
-        } else {
-            s.serialize_field("unsafeParams", &self.unsafe_params)?;
-        }
-        s.end()
-    }
-}
-impl<'de> de::Deserialize<'de> for RequestLogV2 {
-    fn deserialize<D>(d: D) -> Result<RequestLogV2, D::Error>
-    where
-        D: de::Deserializer<'de>,
-    {
-        d.deserialize_struct(
-            "RequestLogV2",
-            &[
-                "type",
-                "time",
-                "method",
-                "protocol",
-                "path",
-                "params",
-                "status",
-                "requestSize",
-                "responseSize",
-                "duration",
-                "uid",
-                "sid",
-                "tokenId",
-                "orgId",
-                "traceId",
-                "unsafeParams",
-            ],
-            Visitor_,
-        )
-    }
-}
-struct Visitor_;
-impl<'de> de::Visitor<'de> for Visitor_ {
-    type Value = RequestLogV2;
-    fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.write_str("map")
-    }
-    fn visit_map<A>(self, mut map_: A) -> Result<RequestLogV2, A::Error>
-    where
-        A: de::MapAccess<'de>,
-    {
-        let mut type_ = None;
-        let mut time = None;
-        let mut method = None;
-        let mut protocol = None;
-        let mut path = None;
-        let mut params = None;
-        let mut status = None;
-        let mut request_size = None;
-        let mut response_size = None;
-        let mut duration = None;
-        let mut uid = None;
-        let mut sid = None;
-        let mut token_id = None;
-        let mut org_id = None;
-        let mut trace_id = None;
-        let mut unsafe_params = None;
-        while let Some(field_) = map_.next_key()? {
-            match field_ {
-                Field_::Type => type_ = Some(map_.next_value()?),
-                Field_::Time => time = Some(map_.next_value()?),
-                Field_::Method => method = Some(map_.next_value()?),
-                Field_::Protocol => protocol = Some(map_.next_value()?),
-                Field_::Path => path = Some(map_.next_value()?),
-                Field_::Params => params = Some(map_.next_value()?),
-                Field_::Status => status = Some(map_.next_value()?),
-                Field_::RequestSize => request_size = Some(map_.next_value()?),
-                Field_::ResponseSize => response_size = Some(map_.next_value()?),
-                Field_::Duration => duration = Some(map_.next_value()?),
-                Field_::Uid => uid = Some(map_.next_value()?),
-                Field_::Sid => sid = Some(map_.next_value()?),
-                Field_::TokenId => token_id = Some(map_.next_value()?),
-                Field_::OrgId => org_id = Some(map_.next_value()?),
-                Field_::TraceId => trace_id = Some(map_.next_value()?),
-                Field_::UnsafeParams => unsafe_params = Some(map_.next_value()?),
-                Field_::Unknown_ => {
-                    map_.next_value::<de::IgnoredAny>()?;
-                }
-            }
-        }
-        let type_ = match type_ {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("type")),
-        };
-        let time = match time {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("time")),
-        };
-        let method = match method {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let protocol = match protocol {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("protocol")),
-        };
-        let path = match path {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("path")),
-        };
-        let params = match params {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let status = match status {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("status")),
-        };
-        let request_size = match request_size {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("requestSize")),
-        };
-        let response_size = match response_size {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("responseSize")),
-        };
-        let duration = match duration {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("duration")),
-        };
-        let uid = match uid {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let sid = match sid {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let token_id = match token_id {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let org_id = match org_id {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let trace_id = match trace_id {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let unsafe_params = match unsafe_params {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        Ok(RequestLogV2 {
-            type_,
-            time,
-            method,
-            protocol,
-            path,
-            params,
-            status,
-            request_size,
-            response_size,
-            duration,
-            uid,
-            sid,
-            token_id,
-            org_id,
-            trace_id,
-            unsafe_params,
-        })
-    }
-}
-enum Field_ {
-    Type,
-    Time,
-    Method,
-    Protocol,
-    Path,
-    Params,
-    Status,
-    RequestSize,
-    ResponseSize,
-    Duration,
-    Uid,
-    Sid,
-    TokenId,
-    OrgId,
-    TraceId,
-    UnsafeParams,
-    Unknown_,
-}
-impl<'de> de::Deserialize<'de> for Field_ {
-    fn deserialize<D>(d: D) -> Result<Field_, D::Error>
-    where
-        D: de::Deserializer<'de>,
-    {
-        d.deserialize_str(FieldVisitor_)
-    }
-}
-struct FieldVisitor_;
-impl<'de> de::Visitor<'de> for FieldVisitor_ {
-    type Value = Field_;
-    fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.write_str("string")
-    }
-    fn visit_str<E>(self, value: &str) -> Result<Field_, E>
-    where
-        E: de::Error,
-    {
-        let v = match value {
-            "type" => Field_::Type,
-            "time" => Field_::Time,
-            "method" => Field_::Method,
-            "protocol" => Field_::Protocol,
-            "path" => Field_::Path,
-            "params" => Field_::Params,
-            "status" => Field_::Status,
-            "requestSize" => Field_::RequestSize,
-            "responseSize" => Field_::ResponseSize,
-            "duration" => Field_::Duration,
-            "uid" => Field_::Uid,
-            "sid" => Field_::Sid,
-            "tokenId" => Field_::TokenId,
-            "orgId" => Field_::OrgId,
-            "traceId" => Field_::TraceId,
-            "unsafeParams" => Field_::UnsafeParams,
-            _ => Field_::Unknown_,
-        };
-        Ok(v)
     }
 }

--- a/witchcraft-server/src/logging/api/sensitivity_tagged_value.rs
+++ b/witchcraft-server/src/logging/api/sensitivity_tagged_value.rs
@@ -1,11 +1,20 @@
-use conjure_object::serde::{ser, de};
-use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use std::fmt;
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+    Debug,
+    Clone,
+    conjure_object::serde::Serialize,
+    conjure_object::serde::Deserialize,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash
+)]
+#[serde(crate = "conjure_object::serde")]
 #[conjure_object::private::staged_builder::staged_builder]
 #[builder(crate = conjure_object::private::staged_builder, update, inline)]
 pub struct SensitivityTaggedValue {
     #[builder(default, list(item(type = String, into)))]
+    #[serde(rename = "level", skip_serializing_if = "Vec::is_empty", default)]
     level: Vec<String>,
     #[builder(
         custom(
@@ -14,6 +23,7 @@ pub struct SensitivityTaggedValue {
             convert = |v|conjure_object::Any::new(v).expect("value failed to serialize")
         )
     )]
+    #[serde(rename = "payload")]
     payload: conjure_object::Any,
 }
 impl SensitivityTaggedValue {
@@ -30,99 +40,5 @@ impl SensitivityTaggedValue {
     #[inline]
     pub fn payload(&self) -> &conjure_object::Any {
         &self.payload
-    }
-}
-impl ser::Serialize for SensitivityTaggedValue {
-    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
-    where
-        S: ser::Serializer,
-    {
-        let mut size = 1usize;
-        let skip_level = self.level.is_empty();
-        if !skip_level {
-            size += 1;
-        }
-        let mut s = s.serialize_struct("SensitivityTaggedValue", size)?;
-        if skip_level {
-            s.skip_field("level")?;
-        } else {
-            s.serialize_field("level", &self.level)?;
-        }
-        s.serialize_field("payload", &self.payload)?;
-        s.end()
-    }
-}
-impl<'de> de::Deserialize<'de> for SensitivityTaggedValue {
-    fn deserialize<D>(d: D) -> Result<SensitivityTaggedValue, D::Error>
-    where
-        D: de::Deserializer<'de>,
-    {
-        d.deserialize_struct("SensitivityTaggedValue", &["level", "payload"], Visitor_)
-    }
-}
-struct Visitor_;
-impl<'de> de::Visitor<'de> for Visitor_ {
-    type Value = SensitivityTaggedValue;
-    fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.write_str("map")
-    }
-    fn visit_map<A>(self, mut map_: A) -> Result<SensitivityTaggedValue, A::Error>
-    where
-        A: de::MapAccess<'de>,
-    {
-        let mut level = None;
-        let mut payload = None;
-        while let Some(field_) = map_.next_key()? {
-            match field_ {
-                Field_::Level => level = Some(map_.next_value()?),
-                Field_::Payload => payload = Some(map_.next_value()?),
-                Field_::Unknown_ => {
-                    map_.next_value::<de::IgnoredAny>()?;
-                }
-            }
-        }
-        let level = match level {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let payload = match payload {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("payload")),
-        };
-        Ok(SensitivityTaggedValue {
-            level,
-            payload,
-        })
-    }
-}
-enum Field_ {
-    Level,
-    Payload,
-    Unknown_,
-}
-impl<'de> de::Deserialize<'de> for Field_ {
-    fn deserialize<D>(d: D) -> Result<Field_, D::Error>
-    where
-        D: de::Deserializer<'de>,
-    {
-        d.deserialize_str(FieldVisitor_)
-    }
-}
-struct FieldVisitor_;
-impl<'de> de::Visitor<'de> for FieldVisitor_ {
-    type Value = Field_;
-    fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.write_str("string")
-    }
-    fn visit_str<E>(self, value: &str) -> Result<Field_, E>
-    where
-        E: de::Error,
-    {
-        let v = match value {
-            "level" => Field_::Level,
-            "payload" => Field_::Payload,
-            _ => Field_::Unknown_,
-        };
-        Ok(v)
     }
 }

--- a/witchcraft-server/src/logging/api/service_log_v1.rs
+++ b/witchcraft-server/src/logging/api/service_log_v1.rs
@@ -1,22 +1,37 @@
-use conjure_object::serde::{ser, de};
-use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use std::fmt;
 ///Definition of the service.1 format.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+    Debug,
+    Clone,
+    conjure_object::serde::Serialize,
+    conjure_object::serde::Deserialize,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash
+)]
+#[serde(crate = "conjure_object::serde")]
 #[conjure_object::private::staged_builder::staged_builder]
 #[builder(crate = conjure_object::private::staged_builder, update, inline)]
 pub struct ServiceLogV1 {
     #[builder(into)]
+    #[serde(rename = "type")]
     type_: String,
+    #[serde(rename = "level")]
     level: super::LogLevel,
+    #[serde(rename = "time")]
     time: conjure_object::DateTime<conjure_object::Utc>,
     #[builder(default, into)]
+    #[serde(rename = "origin", skip_serializing_if = "Option::is_none", default)]
     origin: Option<String>,
     #[builder(default, into)]
+    #[serde(rename = "thread", skip_serializing_if = "Option::is_none", default)]
     thread: Option<String>,
     #[builder(into)]
+    #[serde(rename = "message")]
     message: String,
     #[builder(default, into)]
+    #[serde(rename = "safe", skip_serializing_if = "Option::is_none", default)]
     safe: Option<bool>,
     #[builder(
         default,
@@ -33,18 +48,29 @@ pub struct ServiceLogV1 {
             )
         )
     )]
+    #[serde(
+        rename = "params",
+        skip_serializing_if = "std::collections::BTreeMap::is_empty",
+        default
+    )]
     params: std::collections::BTreeMap<String, conjure_object::Any>,
     #[builder(default, into)]
+    #[serde(rename = "uid", skip_serializing_if = "Option::is_none", default)]
     uid: Option<super::UserId>,
     #[builder(default, into)]
+    #[serde(rename = "sid", skip_serializing_if = "Option::is_none", default)]
     sid: Option<super::SessionId>,
     #[builder(default, into)]
+    #[serde(rename = "tokenId", skip_serializing_if = "Option::is_none", default)]
     token_id: Option<super::TokenId>,
     #[builder(default, into)]
+    #[serde(rename = "orgId", skip_serializing_if = "Option::is_none", default)]
     org_id: Option<super::OrganizationId>,
     #[builder(default, into)]
+    #[serde(rename = "traceId", skip_serializing_if = "Option::is_none", default)]
     trace_id: Option<super::TraceId>,
     #[builder(default, into)]
+    #[serde(rename = "stacktrace", skip_serializing_if = "Option::is_none", default)]
     stacktrace: Option<String>,
     #[builder(
         default,
@@ -61,8 +87,18 @@ pub struct ServiceLogV1 {
             )
         )
     )]
+    #[serde(
+        rename = "unsafeParams",
+        skip_serializing_if = "std::collections::BTreeMap::is_empty",
+        default
+    )]
     unsafe_params: std::collections::BTreeMap<String, conjure_object::Any>,
     #[builder(default, map(key(type = String, into), value(type = String, into)))]
+    #[serde(
+        rename = "tags",
+        skip_serializing_if = "std::collections::BTreeMap::is_empty",
+        default
+    )]
     tags: std::collections::BTreeMap<String, String>,
 }
 impl ServiceLogV1 {
@@ -147,348 +183,5 @@ impl ServiceLogV1 {
     #[inline]
     pub fn tags(&self) -> &std::collections::BTreeMap<String, String> {
         &self.tags
-    }
-}
-impl ser::Serialize for ServiceLogV1 {
-    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
-    where
-        S: ser::Serializer,
-    {
-        let mut size = 4usize;
-        let skip_origin = self.origin.is_none();
-        if !skip_origin {
-            size += 1;
-        }
-        let skip_thread = self.thread.is_none();
-        if !skip_thread {
-            size += 1;
-        }
-        let skip_safe = self.safe.is_none();
-        if !skip_safe {
-            size += 1;
-        }
-        let skip_params = self.params.is_empty();
-        if !skip_params {
-            size += 1;
-        }
-        let skip_uid = self.uid.is_none();
-        if !skip_uid {
-            size += 1;
-        }
-        let skip_sid = self.sid.is_none();
-        if !skip_sid {
-            size += 1;
-        }
-        let skip_token_id = self.token_id.is_none();
-        if !skip_token_id {
-            size += 1;
-        }
-        let skip_org_id = self.org_id.is_none();
-        if !skip_org_id {
-            size += 1;
-        }
-        let skip_trace_id = self.trace_id.is_none();
-        if !skip_trace_id {
-            size += 1;
-        }
-        let skip_stacktrace = self.stacktrace.is_none();
-        if !skip_stacktrace {
-            size += 1;
-        }
-        let skip_unsafe_params = self.unsafe_params.is_empty();
-        if !skip_unsafe_params {
-            size += 1;
-        }
-        let skip_tags = self.tags.is_empty();
-        if !skip_tags {
-            size += 1;
-        }
-        let mut s = s.serialize_struct("ServiceLogV1", size)?;
-        s.serialize_field("type", &self.type_)?;
-        s.serialize_field("level", &self.level)?;
-        s.serialize_field("time", &self.time)?;
-        if skip_origin {
-            s.skip_field("origin")?;
-        } else {
-            s.serialize_field("origin", &self.origin)?;
-        }
-        if skip_thread {
-            s.skip_field("thread")?;
-        } else {
-            s.serialize_field("thread", &self.thread)?;
-        }
-        s.serialize_field("message", &self.message)?;
-        if skip_safe {
-            s.skip_field("safe")?;
-        } else {
-            s.serialize_field("safe", &self.safe)?;
-        }
-        if skip_params {
-            s.skip_field("params")?;
-        } else {
-            s.serialize_field("params", &self.params)?;
-        }
-        if skip_uid {
-            s.skip_field("uid")?;
-        } else {
-            s.serialize_field("uid", &self.uid)?;
-        }
-        if skip_sid {
-            s.skip_field("sid")?;
-        } else {
-            s.serialize_field("sid", &self.sid)?;
-        }
-        if skip_token_id {
-            s.skip_field("tokenId")?;
-        } else {
-            s.serialize_field("tokenId", &self.token_id)?;
-        }
-        if skip_org_id {
-            s.skip_field("orgId")?;
-        } else {
-            s.serialize_field("orgId", &self.org_id)?;
-        }
-        if skip_trace_id {
-            s.skip_field("traceId")?;
-        } else {
-            s.serialize_field("traceId", &self.trace_id)?;
-        }
-        if skip_stacktrace {
-            s.skip_field("stacktrace")?;
-        } else {
-            s.serialize_field("stacktrace", &self.stacktrace)?;
-        }
-        if skip_unsafe_params {
-            s.skip_field("unsafeParams")?;
-        } else {
-            s.serialize_field("unsafeParams", &self.unsafe_params)?;
-        }
-        if skip_tags {
-            s.skip_field("tags")?;
-        } else {
-            s.serialize_field("tags", &self.tags)?;
-        }
-        s.end()
-    }
-}
-impl<'de> de::Deserialize<'de> for ServiceLogV1 {
-    fn deserialize<D>(d: D) -> Result<ServiceLogV1, D::Error>
-    where
-        D: de::Deserializer<'de>,
-    {
-        d.deserialize_struct(
-            "ServiceLogV1",
-            &[
-                "type",
-                "level",
-                "time",
-                "origin",
-                "thread",
-                "message",
-                "safe",
-                "params",
-                "uid",
-                "sid",
-                "tokenId",
-                "orgId",
-                "traceId",
-                "stacktrace",
-                "unsafeParams",
-                "tags",
-            ],
-            Visitor_,
-        )
-    }
-}
-struct Visitor_;
-impl<'de> de::Visitor<'de> for Visitor_ {
-    type Value = ServiceLogV1;
-    fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.write_str("map")
-    }
-    fn visit_map<A>(self, mut map_: A) -> Result<ServiceLogV1, A::Error>
-    where
-        A: de::MapAccess<'de>,
-    {
-        let mut type_ = None;
-        let mut level = None;
-        let mut time = None;
-        let mut origin = None;
-        let mut thread = None;
-        let mut message = None;
-        let mut safe = None;
-        let mut params = None;
-        let mut uid = None;
-        let mut sid = None;
-        let mut token_id = None;
-        let mut org_id = None;
-        let mut trace_id = None;
-        let mut stacktrace = None;
-        let mut unsafe_params = None;
-        let mut tags = None;
-        while let Some(field_) = map_.next_key()? {
-            match field_ {
-                Field_::Type => type_ = Some(map_.next_value()?),
-                Field_::Level => level = Some(map_.next_value()?),
-                Field_::Time => time = Some(map_.next_value()?),
-                Field_::Origin => origin = Some(map_.next_value()?),
-                Field_::Thread => thread = Some(map_.next_value()?),
-                Field_::Message => message = Some(map_.next_value()?),
-                Field_::Safe => safe = Some(map_.next_value()?),
-                Field_::Params => params = Some(map_.next_value()?),
-                Field_::Uid => uid = Some(map_.next_value()?),
-                Field_::Sid => sid = Some(map_.next_value()?),
-                Field_::TokenId => token_id = Some(map_.next_value()?),
-                Field_::OrgId => org_id = Some(map_.next_value()?),
-                Field_::TraceId => trace_id = Some(map_.next_value()?),
-                Field_::Stacktrace => stacktrace = Some(map_.next_value()?),
-                Field_::UnsafeParams => unsafe_params = Some(map_.next_value()?),
-                Field_::Tags => tags = Some(map_.next_value()?),
-                Field_::Unknown_ => {
-                    map_.next_value::<de::IgnoredAny>()?;
-                }
-            }
-        }
-        let type_ = match type_ {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("type")),
-        };
-        let level = match level {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("level")),
-        };
-        let time = match time {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("time")),
-        };
-        let origin = match origin {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let thread = match thread {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let message = match message {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("message")),
-        };
-        let safe = match safe {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let params = match params {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let uid = match uid {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let sid = match sid {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let token_id = match token_id {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let org_id = match org_id {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let trace_id = match trace_id {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let stacktrace = match stacktrace {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let unsafe_params = match unsafe_params {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let tags = match tags {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        Ok(ServiceLogV1 {
-            type_,
-            level,
-            time,
-            origin,
-            thread,
-            message,
-            safe,
-            params,
-            uid,
-            sid,
-            token_id,
-            org_id,
-            trace_id,
-            stacktrace,
-            unsafe_params,
-            tags,
-        })
-    }
-}
-enum Field_ {
-    Type,
-    Level,
-    Time,
-    Origin,
-    Thread,
-    Message,
-    Safe,
-    Params,
-    Uid,
-    Sid,
-    TokenId,
-    OrgId,
-    TraceId,
-    Stacktrace,
-    UnsafeParams,
-    Tags,
-    Unknown_,
-}
-impl<'de> de::Deserialize<'de> for Field_ {
-    fn deserialize<D>(d: D) -> Result<Field_, D::Error>
-    where
-        D: de::Deserializer<'de>,
-    {
-        d.deserialize_str(FieldVisitor_)
-    }
-}
-struct FieldVisitor_;
-impl<'de> de::Visitor<'de> for FieldVisitor_ {
-    type Value = Field_;
-    fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.write_str("string")
-    }
-    fn visit_str<E>(self, value: &str) -> Result<Field_, E>
-    where
-        E: de::Error,
-    {
-        let v = match value {
-            "type" => Field_::Type,
-            "level" => Field_::Level,
-            "time" => Field_::Time,
-            "origin" => Field_::Origin,
-            "thread" => Field_::Thread,
-            "message" => Field_::Message,
-            "safe" => Field_::Safe,
-            "params" => Field_::Params,
-            "uid" => Field_::Uid,
-            "sid" => Field_::Sid,
-            "tokenId" => Field_::TokenId,
-            "orgId" => Field_::OrgId,
-            "traceId" => Field_::TraceId,
-            "stacktrace" => Field_::Stacktrace,
-            "unsafeParams" => Field_::UnsafeParams,
-            "tags" => Field_::Tags,
-            _ => Field_::Unknown_,
-        };
-        Ok(v)
     }
 }

--- a/witchcraft-server/src/logging/api/session_id.rs
+++ b/witchcraft-server/src/logging/api/session_id.rs
@@ -1,5 +1,16 @@
-use conjure_object::serde::{ser, de};
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[derive(
+    Debug,
+    Clone,
+    conjure_object::serde::Deserialize,
+    conjure_object::serde::Serialize,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Default
+)]
+#[serde(crate = "conjure_object::serde", transparent)]
 pub struct SessionId(pub String);
 impl std::fmt::Display for SessionId {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -35,21 +46,5 @@ impl std::ops::DerefMut for SessionId {
     #[inline]
     fn deref_mut(&mut self) -> &mut String {
         &mut self.0
-    }
-}
-impl ser::Serialize for SessionId {
-    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
-    where
-        S: ser::Serializer,
-    {
-        self.0.serialize(s)
-    }
-}
-impl<'de> de::Deserialize<'de> for SessionId {
-    fn deserialize<D>(d: D) -> Result<SessionId, D::Error>
-    where
-        D: de::Deserializer<'de>,
-    {
-        de::Deserialize::deserialize(d).map(SessionId)
     }
 }

--- a/witchcraft-server/src/logging/api/span.rs
+++ b/witchcraft-server/src/logging/api/span.rs
@@ -1,24 +1,44 @@
-use conjure_object::serde::{ser, de};
-use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use std::fmt;
 ///A Zipkin-compatible Span object.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+    Debug,
+    Clone,
+    conjure_object::serde::Serialize,
+    conjure_object::serde::Deserialize,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash
+)]
+#[serde(crate = "conjure_object::serde")]
 #[conjure_object::private::staged_builder::staged_builder]
 #[builder(crate = conjure_object::private::staged_builder, update, inline)]
 pub struct Span {
     #[builder(into)]
+    #[serde(rename = "traceId")]
     trace_id: String,
     #[builder(into)]
+    #[serde(rename = "id")]
     id: String,
     #[builder(into)]
+    #[serde(rename = "name")]
     name: String,
     #[builder(default, into)]
+    #[serde(rename = "parentId", skip_serializing_if = "Option::is_none", default)]
     parent_id: Option<String>,
+    #[serde(rename = "timestamp")]
     timestamp: conjure_object::SafeLong,
+    #[serde(rename = "duration")]
     duration: conjure_object::SafeLong,
     #[builder(default, list(item(type = super::Annotation)))]
+    #[serde(rename = "annotations", skip_serializing_if = "Vec::is_empty", default)]
     annotations: Vec<super::Annotation>,
     #[builder(default, map(key(type = String, into), value(type = String, into)))]
+    #[serde(
+        rename = "tags",
+        skip_serializing_if = "std::collections::BTreeMap::is_empty",
+        default
+    )]
     tags: std::collections::BTreeMap<String, String>,
 }
 impl Span {
@@ -60,188 +80,5 @@ impl Span {
     #[inline]
     pub fn tags(&self) -> &std::collections::BTreeMap<String, String> {
         &self.tags
-    }
-}
-impl ser::Serialize for Span {
-    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
-    where
-        S: ser::Serializer,
-    {
-        let mut size = 5usize;
-        let skip_parent_id = self.parent_id.is_none();
-        if !skip_parent_id {
-            size += 1;
-        }
-        let skip_annotations = self.annotations.is_empty();
-        if !skip_annotations {
-            size += 1;
-        }
-        let skip_tags = self.tags.is_empty();
-        if !skip_tags {
-            size += 1;
-        }
-        let mut s = s.serialize_struct("Span", size)?;
-        s.serialize_field("traceId", &self.trace_id)?;
-        s.serialize_field("id", &self.id)?;
-        s.serialize_field("name", &self.name)?;
-        if skip_parent_id {
-            s.skip_field("parentId")?;
-        } else {
-            s.serialize_field("parentId", &self.parent_id)?;
-        }
-        s.serialize_field("timestamp", &self.timestamp)?;
-        s.serialize_field("duration", &self.duration)?;
-        if skip_annotations {
-            s.skip_field("annotations")?;
-        } else {
-            s.serialize_field("annotations", &self.annotations)?;
-        }
-        if skip_tags {
-            s.skip_field("tags")?;
-        } else {
-            s.serialize_field("tags", &self.tags)?;
-        }
-        s.end()
-    }
-}
-impl<'de> de::Deserialize<'de> for Span {
-    fn deserialize<D>(d: D) -> Result<Span, D::Error>
-    where
-        D: de::Deserializer<'de>,
-    {
-        d.deserialize_struct(
-            "Span",
-            &[
-                "traceId",
-                "id",
-                "name",
-                "parentId",
-                "timestamp",
-                "duration",
-                "annotations",
-                "tags",
-            ],
-            Visitor_,
-        )
-    }
-}
-struct Visitor_;
-impl<'de> de::Visitor<'de> for Visitor_ {
-    type Value = Span;
-    fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.write_str("map")
-    }
-    fn visit_map<A>(self, mut map_: A) -> Result<Span, A::Error>
-    where
-        A: de::MapAccess<'de>,
-    {
-        let mut trace_id = None;
-        let mut id = None;
-        let mut name = None;
-        let mut parent_id = None;
-        let mut timestamp = None;
-        let mut duration = None;
-        let mut annotations = None;
-        let mut tags = None;
-        while let Some(field_) = map_.next_key()? {
-            match field_ {
-                Field_::TraceId => trace_id = Some(map_.next_value()?),
-                Field_::Id => id = Some(map_.next_value()?),
-                Field_::Name => name = Some(map_.next_value()?),
-                Field_::ParentId => parent_id = Some(map_.next_value()?),
-                Field_::Timestamp => timestamp = Some(map_.next_value()?),
-                Field_::Duration => duration = Some(map_.next_value()?),
-                Field_::Annotations => annotations = Some(map_.next_value()?),
-                Field_::Tags => tags = Some(map_.next_value()?),
-                Field_::Unknown_ => {
-                    map_.next_value::<de::IgnoredAny>()?;
-                }
-            }
-        }
-        let trace_id = match trace_id {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("traceId")),
-        };
-        let id = match id {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("id")),
-        };
-        let name = match name {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("name")),
-        };
-        let parent_id = match parent_id {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let timestamp = match timestamp {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("timestamp")),
-        };
-        let duration = match duration {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("duration")),
-        };
-        let annotations = match annotations {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let tags = match tags {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        Ok(Span {
-            trace_id,
-            id,
-            name,
-            parent_id,
-            timestamp,
-            duration,
-            annotations,
-            tags,
-        })
-    }
-}
-enum Field_ {
-    TraceId,
-    Id,
-    Name,
-    ParentId,
-    Timestamp,
-    Duration,
-    Annotations,
-    Tags,
-    Unknown_,
-}
-impl<'de> de::Deserialize<'de> for Field_ {
-    fn deserialize<D>(d: D) -> Result<Field_, D::Error>
-    where
-        D: de::Deserializer<'de>,
-    {
-        d.deserialize_str(FieldVisitor_)
-    }
-}
-struct FieldVisitor_;
-impl<'de> de::Visitor<'de> for FieldVisitor_ {
-    type Value = Field_;
-    fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.write_str("string")
-    }
-    fn visit_str<E>(self, value: &str) -> Result<Field_, E>
-    where
-        E: de::Error,
-    {
-        let v = match value {
-            "traceId" => Field_::TraceId,
-            "id" => Field_::Id,
-            "name" => Field_::Name,
-            "parentId" => Field_::ParentId,
-            "timestamp" => Field_::Timestamp,
-            "duration" => Field_::Duration,
-            "annotations" => Field_::Annotations,
-            "tags" => Field_::Tags,
-            _ => Field_::Unknown_,
-        };
-        Ok(v)
     }
 }

--- a/witchcraft-server/src/logging/api/stack_frame_v1.rs
+++ b/witchcraft-server/src/logging/api/stack_frame_v1.rs
@@ -1,17 +1,29 @@
-use conjure_object::serde::{ser, de};
-use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use std::fmt;
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+    Debug,
+    Clone,
+    conjure_object::serde::Serialize,
+    conjure_object::serde::Deserialize,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash
+)]
+#[serde(crate = "conjure_object::serde")]
 #[conjure_object::private::staged_builder::staged_builder]
 #[builder(crate = conjure_object::private::staged_builder, update, inline)]
 pub struct StackFrameV1 {
     #[builder(default, into)]
+    #[serde(rename = "address", skip_serializing_if = "Option::is_none", default)]
     address: Option<String>,
     #[builder(default, into)]
+    #[serde(rename = "procedure", skip_serializing_if = "Option::is_none", default)]
     procedure: Option<String>,
     #[builder(default, into)]
+    #[serde(rename = "file", skip_serializing_if = "Option::is_none", default)]
     file: Option<String>,
     #[builder(default, into)]
+    #[serde(rename = "line", skip_serializing_if = "Option::is_none", default)]
     line: Option<i32>,
     #[builder(
         default,
@@ -27,6 +39,11 @@ pub struct StackFrameV1 {
                 )
             )
         )
+    )]
+    #[serde(
+        rename = "params",
+        skip_serializing_if = "std::collections::BTreeMap::is_empty",
+        default
     )]
     params: std::collections::BTreeMap<String, conjure_object::Any>,
 }
@@ -60,165 +77,5 @@ impl StackFrameV1 {
     #[inline]
     pub fn params(&self) -> &std::collections::BTreeMap<String, conjure_object::Any> {
         &self.params
-    }
-}
-impl ser::Serialize for StackFrameV1 {
-    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
-    where
-        S: ser::Serializer,
-    {
-        let mut size = 0usize;
-        let skip_address = self.address.is_none();
-        if !skip_address {
-            size += 1;
-        }
-        let skip_procedure = self.procedure.is_none();
-        if !skip_procedure {
-            size += 1;
-        }
-        let skip_file = self.file.is_none();
-        if !skip_file {
-            size += 1;
-        }
-        let skip_line = self.line.is_none();
-        if !skip_line {
-            size += 1;
-        }
-        let skip_params = self.params.is_empty();
-        if !skip_params {
-            size += 1;
-        }
-        let mut s = s.serialize_struct("StackFrameV1", size)?;
-        if skip_address {
-            s.skip_field("address")?;
-        } else {
-            s.serialize_field("address", &self.address)?;
-        }
-        if skip_procedure {
-            s.skip_field("procedure")?;
-        } else {
-            s.serialize_field("procedure", &self.procedure)?;
-        }
-        if skip_file {
-            s.skip_field("file")?;
-        } else {
-            s.serialize_field("file", &self.file)?;
-        }
-        if skip_line {
-            s.skip_field("line")?;
-        } else {
-            s.serialize_field("line", &self.line)?;
-        }
-        if skip_params {
-            s.skip_field("params")?;
-        } else {
-            s.serialize_field("params", &self.params)?;
-        }
-        s.end()
-    }
-}
-impl<'de> de::Deserialize<'de> for StackFrameV1 {
-    fn deserialize<D>(d: D) -> Result<StackFrameV1, D::Error>
-    where
-        D: de::Deserializer<'de>,
-    {
-        d.deserialize_struct(
-            "StackFrameV1",
-            &["address", "procedure", "file", "line", "params"],
-            Visitor_,
-        )
-    }
-}
-struct Visitor_;
-impl<'de> de::Visitor<'de> for Visitor_ {
-    type Value = StackFrameV1;
-    fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.write_str("map")
-    }
-    fn visit_map<A>(self, mut map_: A) -> Result<StackFrameV1, A::Error>
-    where
-        A: de::MapAccess<'de>,
-    {
-        let mut address = None;
-        let mut procedure = None;
-        let mut file = None;
-        let mut line = None;
-        let mut params = None;
-        while let Some(field_) = map_.next_key()? {
-            match field_ {
-                Field_::Address => address = Some(map_.next_value()?),
-                Field_::Procedure => procedure = Some(map_.next_value()?),
-                Field_::File => file = Some(map_.next_value()?),
-                Field_::Line => line = Some(map_.next_value()?),
-                Field_::Params => params = Some(map_.next_value()?),
-                Field_::Unknown_ => {
-                    map_.next_value::<de::IgnoredAny>()?;
-                }
-            }
-        }
-        let address = match address {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let procedure = match procedure {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let file = match file {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let line = match line {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let params = match params {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        Ok(StackFrameV1 {
-            address,
-            procedure,
-            file,
-            line,
-            params,
-        })
-    }
-}
-enum Field_ {
-    Address,
-    Procedure,
-    File,
-    Line,
-    Params,
-    Unknown_,
-}
-impl<'de> de::Deserialize<'de> for Field_ {
-    fn deserialize<D>(d: D) -> Result<Field_, D::Error>
-    where
-        D: de::Deserializer<'de>,
-    {
-        d.deserialize_str(FieldVisitor_)
-    }
-}
-struct FieldVisitor_;
-impl<'de> de::Visitor<'de> for FieldVisitor_ {
-    type Value = Field_;
-    fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.write_str("string")
-    }
-    fn visit_str<E>(self, value: &str) -> Result<Field_, E>
-    where
-        E: de::Error,
-    {
-        let v = match value {
-            "address" => Field_::Address,
-            "procedure" => Field_::Procedure,
-            "file" => Field_::File,
-            "line" => Field_::Line,
-            "params" => Field_::Params,
-            _ => Field_::Unknown_,
-        };
-        Ok(v)
     }
 }

--- a/witchcraft-server/src/logging/api/thread_dump_v1.rs
+++ b/witchcraft-server/src/logging/api/thread_dump_v1.rs
@@ -1,11 +1,20 @@
-use conjure_object::serde::{ser, de};
-use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use std::fmt;
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+    Debug,
+    Clone,
+    conjure_object::serde::Serialize,
+    conjure_object::serde::Deserialize,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash
+)]
+#[serde(crate = "conjure_object::serde")]
 #[conjure_object::private::staged_builder::staged_builder]
 #[builder(crate = conjure_object::private::staged_builder, update, inline)]
 pub struct ThreadDumpV1 {
     #[builder(default, list(item(type = super::ThreadInfoV1)))]
+    #[serde(rename = "threads", skip_serializing_if = "Vec::is_empty", default)]
     threads: Vec<super::ThreadInfoV1>,
 }
 impl ThreadDumpV1 {
@@ -18,87 +27,5 @@ impl ThreadDumpV1 {
     #[inline]
     pub fn threads(&self) -> &[super::ThreadInfoV1] {
         &*self.threads
-    }
-}
-impl ser::Serialize for ThreadDumpV1 {
-    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
-    where
-        S: ser::Serializer,
-    {
-        let mut size = 0usize;
-        let skip_threads = self.threads.is_empty();
-        if !skip_threads {
-            size += 1;
-        }
-        let mut s = s.serialize_struct("ThreadDumpV1", size)?;
-        if skip_threads {
-            s.skip_field("threads")?;
-        } else {
-            s.serialize_field("threads", &self.threads)?;
-        }
-        s.end()
-    }
-}
-impl<'de> de::Deserialize<'de> for ThreadDumpV1 {
-    fn deserialize<D>(d: D) -> Result<ThreadDumpV1, D::Error>
-    where
-        D: de::Deserializer<'de>,
-    {
-        d.deserialize_struct("ThreadDumpV1", &["threads"], Visitor_)
-    }
-}
-struct Visitor_;
-impl<'de> de::Visitor<'de> for Visitor_ {
-    type Value = ThreadDumpV1;
-    fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.write_str("map")
-    }
-    fn visit_map<A>(self, mut map_: A) -> Result<ThreadDumpV1, A::Error>
-    where
-        A: de::MapAccess<'de>,
-    {
-        let mut threads = None;
-        while let Some(field_) = map_.next_key()? {
-            match field_ {
-                Field_::Threads => threads = Some(map_.next_value()?),
-                Field_::Unknown_ => {
-                    map_.next_value::<de::IgnoredAny>()?;
-                }
-            }
-        }
-        let threads = match threads {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        Ok(ThreadDumpV1 { threads })
-    }
-}
-enum Field_ {
-    Threads,
-    Unknown_,
-}
-impl<'de> de::Deserialize<'de> for Field_ {
-    fn deserialize<D>(d: D) -> Result<Field_, D::Error>
-    where
-        D: de::Deserializer<'de>,
-    {
-        d.deserialize_str(FieldVisitor_)
-    }
-}
-struct FieldVisitor_;
-impl<'de> de::Visitor<'de> for FieldVisitor_ {
-    type Value = Field_;
-    fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.write_str("string")
-    }
-    fn visit_str<E>(self, value: &str) -> Result<Field_, E>
-    where
-        E: de::Error,
-    {
-        let v = match value {
-            "threads" => Field_::Threads,
-            _ => Field_::Unknown_,
-        };
-        Ok(v)
     }
 }

--- a/witchcraft-server/src/logging/api/thread_info_v1.rs
+++ b/witchcraft-server/src/logging/api/thread_info_v1.rs
@@ -1,15 +1,26 @@
-use conjure_object::serde::{ser, de};
-use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use std::fmt;
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+    Debug,
+    Clone,
+    conjure_object::serde::Serialize,
+    conjure_object::serde::Deserialize,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash
+)]
+#[serde(crate = "conjure_object::serde")]
 #[conjure_object::private::staged_builder::staged_builder]
 #[builder(crate = conjure_object::private::staged_builder, update, inline)]
 pub struct ThreadInfoV1 {
     #[builder(default, into)]
+    #[serde(rename = "id", skip_serializing_if = "Option::is_none", default)]
     id: Option<conjure_object::SafeLong>,
     #[builder(default, into)]
+    #[serde(rename = "name", skip_serializing_if = "Option::is_none", default)]
     name: Option<String>,
     #[builder(default, list(item(type = super::StackFrameV1)))]
+    #[serde(rename = "stackTrace", skip_serializing_if = "Vec::is_empty", default)]
     stack_trace: Vec<super::StackFrameV1>,
     #[builder(
         default,
@@ -25,6 +36,11 @@ pub struct ThreadInfoV1 {
                 )
             )
         )
+    )]
+    #[serde(
+        rename = "params",
+        skip_serializing_if = "std::collections::BTreeMap::is_empty",
+        default
     )]
     params: std::collections::BTreeMap<String, conjure_object::Any>,
 }
@@ -53,147 +69,5 @@ impl ThreadInfoV1 {
     #[inline]
     pub fn params(&self) -> &std::collections::BTreeMap<String, conjure_object::Any> {
         &self.params
-    }
-}
-impl ser::Serialize for ThreadInfoV1 {
-    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
-    where
-        S: ser::Serializer,
-    {
-        let mut size = 0usize;
-        let skip_id = self.id.is_none();
-        if !skip_id {
-            size += 1;
-        }
-        let skip_name = self.name.is_none();
-        if !skip_name {
-            size += 1;
-        }
-        let skip_stack_trace = self.stack_trace.is_empty();
-        if !skip_stack_trace {
-            size += 1;
-        }
-        let skip_params = self.params.is_empty();
-        if !skip_params {
-            size += 1;
-        }
-        let mut s = s.serialize_struct("ThreadInfoV1", size)?;
-        if skip_id {
-            s.skip_field("id")?;
-        } else {
-            s.serialize_field("id", &self.id)?;
-        }
-        if skip_name {
-            s.skip_field("name")?;
-        } else {
-            s.serialize_field("name", &self.name)?;
-        }
-        if skip_stack_trace {
-            s.skip_field("stackTrace")?;
-        } else {
-            s.serialize_field("stackTrace", &self.stack_trace)?;
-        }
-        if skip_params {
-            s.skip_field("params")?;
-        } else {
-            s.serialize_field("params", &self.params)?;
-        }
-        s.end()
-    }
-}
-impl<'de> de::Deserialize<'de> for ThreadInfoV1 {
-    fn deserialize<D>(d: D) -> Result<ThreadInfoV1, D::Error>
-    where
-        D: de::Deserializer<'de>,
-    {
-        d.deserialize_struct(
-            "ThreadInfoV1",
-            &["id", "name", "stackTrace", "params"],
-            Visitor_,
-        )
-    }
-}
-struct Visitor_;
-impl<'de> de::Visitor<'de> for Visitor_ {
-    type Value = ThreadInfoV1;
-    fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.write_str("map")
-    }
-    fn visit_map<A>(self, mut map_: A) -> Result<ThreadInfoV1, A::Error>
-    where
-        A: de::MapAccess<'de>,
-    {
-        let mut id = None;
-        let mut name = None;
-        let mut stack_trace = None;
-        let mut params = None;
-        while let Some(field_) = map_.next_key()? {
-            match field_ {
-                Field_::Id => id = Some(map_.next_value()?),
-                Field_::Name => name = Some(map_.next_value()?),
-                Field_::StackTrace => stack_trace = Some(map_.next_value()?),
-                Field_::Params => params = Some(map_.next_value()?),
-                Field_::Unknown_ => {
-                    map_.next_value::<de::IgnoredAny>()?;
-                }
-            }
-        }
-        let id = match id {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let name = match name {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let stack_trace = match stack_trace {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let params = match params {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        Ok(ThreadInfoV1 {
-            id,
-            name,
-            stack_trace,
-            params,
-        })
-    }
-}
-enum Field_ {
-    Id,
-    Name,
-    StackTrace,
-    Params,
-    Unknown_,
-}
-impl<'de> de::Deserialize<'de> for Field_ {
-    fn deserialize<D>(d: D) -> Result<Field_, D::Error>
-    where
-        D: de::Deserializer<'de>,
-    {
-        d.deserialize_str(FieldVisitor_)
-    }
-}
-struct FieldVisitor_;
-impl<'de> de::Visitor<'de> for FieldVisitor_ {
-    type Value = Field_;
-    fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.write_str("string")
-    }
-    fn visit_str<E>(self, value: &str) -> Result<Field_, E>
-    where
-        E: de::Error,
-    {
-        let v = match value {
-            "id" => Field_::Id,
-            "name" => Field_::Name,
-            "stackTrace" => Field_::StackTrace,
-            "params" => Field_::Params,
-            _ => Field_::Unknown_,
-        };
-        Ok(v)
     }
 }

--- a/witchcraft-server/src/logging/api/token_id.rs
+++ b/witchcraft-server/src/logging/api/token_id.rs
@@ -1,5 +1,16 @@
-use conjure_object::serde::{ser, de};
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[derive(
+    Debug,
+    Clone,
+    conjure_object::serde::Deserialize,
+    conjure_object::serde::Serialize,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Default
+)]
+#[serde(crate = "conjure_object::serde", transparent)]
 pub struct TokenId(pub String);
 impl std::fmt::Display for TokenId {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -35,21 +46,5 @@ impl std::ops::DerefMut for TokenId {
     #[inline]
     fn deref_mut(&mut self) -> &mut String {
         &mut self.0
-    }
-}
-impl ser::Serialize for TokenId {
-    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
-    where
-        S: ser::Serializer,
-    {
-        self.0.serialize(s)
-    }
-}
-impl<'de> de::Deserialize<'de> for TokenId {
-    fn deserialize<D>(d: D) -> Result<TokenId, D::Error>
-    where
-        D: de::Deserializer<'de>,
-    {
-        de::Deserialize::deserialize(d).map(TokenId)
     }
 }

--- a/witchcraft-server/src/logging/api/trace_id.rs
+++ b/witchcraft-server/src/logging/api/trace_id.rs
@@ -1,5 +1,16 @@
-use conjure_object::serde::{ser, de};
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[derive(
+    Debug,
+    Clone,
+    conjure_object::serde::Deserialize,
+    conjure_object::serde::Serialize,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Default
+)]
+#[serde(crate = "conjure_object::serde", transparent)]
 pub struct TraceId(pub String);
 impl std::fmt::Display for TraceId {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -35,21 +46,5 @@ impl std::ops::DerefMut for TraceId {
     #[inline]
     fn deref_mut(&mut self) -> &mut String {
         &mut self.0
-    }
-}
-impl ser::Serialize for TraceId {
-    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
-    where
-        S: ser::Serializer,
-    {
-        self.0.serialize(s)
-    }
-}
-impl<'de> de::Deserialize<'de> for TraceId {
-    fn deserialize<D>(d: D) -> Result<TraceId, D::Error>
-    where
-        D: de::Deserializer<'de>,
-    {
-        de::Deserialize::deserialize(d).map(TraceId)
     }
 }

--- a/witchcraft-server/src/logging/api/trace_log_v1.rs
+++ b/witchcraft-server/src/logging/api/trace_log_v1.rs
@@ -1,21 +1,35 @@
-use conjure_object::serde::{ser, de};
-use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use std::fmt;
 ///Definition of the trace.1 format.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+    Debug,
+    Clone,
+    conjure_object::serde::Serialize,
+    conjure_object::serde::Deserialize,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash
+)]
+#[serde(crate = "conjure_object::serde")]
 #[conjure_object::private::staged_builder::staged_builder]
 #[builder(crate = conjure_object::private::staged_builder, update, inline)]
 pub struct TraceLogV1 {
     #[builder(into)]
+    #[serde(rename = "type")]
     type_: String,
+    #[serde(rename = "time")]
     time: conjure_object::DateTime<conjure_object::Utc>,
     #[builder(default, into)]
+    #[serde(rename = "uid", skip_serializing_if = "Option::is_none", default)]
     uid: Option<super::UserId>,
     #[builder(default, into)]
+    #[serde(rename = "sid", skip_serializing_if = "Option::is_none", default)]
     sid: Option<super::SessionId>,
     #[builder(default, into)]
+    #[serde(rename = "tokenId", skip_serializing_if = "Option::is_none", default)]
     token_id: Option<super::TokenId>,
     #[builder(default, into)]
+    #[serde(rename = "orgId", skip_serializing_if = "Option::is_none", default)]
     org_id: Option<super::OrganizationId>,
     #[builder(
         default,
@@ -32,8 +46,14 @@ pub struct TraceLogV1 {
             )
         )
     )]
+    #[serde(
+        rename = "unsafeParams",
+        skip_serializing_if = "std::collections::BTreeMap::is_empty",
+        default
+    )]
     unsafe_params: std::collections::BTreeMap<String, conjure_object::Any>,
     #[builder(custom(type = super::Span, convert = Box::new))]
+    #[serde(rename = "span")]
     span: Box<super::Span>,
 }
 impl TraceLogV1 {
@@ -79,195 +99,5 @@ impl TraceLogV1 {
     #[inline]
     pub fn span(&self) -> &super::Span {
         &*self.span
-    }
-}
-impl ser::Serialize for TraceLogV1 {
-    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
-    where
-        S: ser::Serializer,
-    {
-        let mut size = 3usize;
-        let skip_uid = self.uid.is_none();
-        if !skip_uid {
-            size += 1;
-        }
-        let skip_sid = self.sid.is_none();
-        if !skip_sid {
-            size += 1;
-        }
-        let skip_token_id = self.token_id.is_none();
-        if !skip_token_id {
-            size += 1;
-        }
-        let skip_org_id = self.org_id.is_none();
-        if !skip_org_id {
-            size += 1;
-        }
-        let skip_unsafe_params = self.unsafe_params.is_empty();
-        if !skip_unsafe_params {
-            size += 1;
-        }
-        let mut s = s.serialize_struct("TraceLogV1", size)?;
-        s.serialize_field("type", &self.type_)?;
-        s.serialize_field("time", &self.time)?;
-        if skip_uid {
-            s.skip_field("uid")?;
-        } else {
-            s.serialize_field("uid", &self.uid)?;
-        }
-        if skip_sid {
-            s.skip_field("sid")?;
-        } else {
-            s.serialize_field("sid", &self.sid)?;
-        }
-        if skip_token_id {
-            s.skip_field("tokenId")?;
-        } else {
-            s.serialize_field("tokenId", &self.token_id)?;
-        }
-        if skip_org_id {
-            s.skip_field("orgId")?;
-        } else {
-            s.serialize_field("orgId", &self.org_id)?;
-        }
-        if skip_unsafe_params {
-            s.skip_field("unsafeParams")?;
-        } else {
-            s.serialize_field("unsafeParams", &self.unsafe_params)?;
-        }
-        s.serialize_field("span", &self.span)?;
-        s.end()
-    }
-}
-impl<'de> de::Deserialize<'de> for TraceLogV1 {
-    fn deserialize<D>(d: D) -> Result<TraceLogV1, D::Error>
-    where
-        D: de::Deserializer<'de>,
-    {
-        d.deserialize_struct(
-            "TraceLogV1",
-            &["type", "time", "uid", "sid", "tokenId", "orgId", "unsafeParams", "span"],
-            Visitor_,
-        )
-    }
-}
-struct Visitor_;
-impl<'de> de::Visitor<'de> for Visitor_ {
-    type Value = TraceLogV1;
-    fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.write_str("map")
-    }
-    fn visit_map<A>(self, mut map_: A) -> Result<TraceLogV1, A::Error>
-    where
-        A: de::MapAccess<'de>,
-    {
-        let mut type_ = None;
-        let mut time = None;
-        let mut uid = None;
-        let mut sid = None;
-        let mut token_id = None;
-        let mut org_id = None;
-        let mut unsafe_params = None;
-        let mut span = None;
-        while let Some(field_) = map_.next_key()? {
-            match field_ {
-                Field_::Type => type_ = Some(map_.next_value()?),
-                Field_::Time => time = Some(map_.next_value()?),
-                Field_::Uid => uid = Some(map_.next_value()?),
-                Field_::Sid => sid = Some(map_.next_value()?),
-                Field_::TokenId => token_id = Some(map_.next_value()?),
-                Field_::OrgId => org_id = Some(map_.next_value()?),
-                Field_::UnsafeParams => unsafe_params = Some(map_.next_value()?),
-                Field_::Span => span = Some(map_.next_value()?),
-                Field_::Unknown_ => {
-                    map_.next_value::<de::IgnoredAny>()?;
-                }
-            }
-        }
-        let type_ = match type_ {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("type")),
-        };
-        let time = match time {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("time")),
-        };
-        let uid = match uid {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let sid = match sid {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let token_id = match token_id {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let org_id = match org_id {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let unsafe_params = match unsafe_params {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let span = match span {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("span")),
-        };
-        Ok(TraceLogV1 {
-            type_,
-            time,
-            uid,
-            sid,
-            token_id,
-            org_id,
-            unsafe_params,
-            span,
-        })
-    }
-}
-enum Field_ {
-    Type,
-    Time,
-    Uid,
-    Sid,
-    TokenId,
-    OrgId,
-    UnsafeParams,
-    Span,
-    Unknown_,
-}
-impl<'de> de::Deserialize<'de> for Field_ {
-    fn deserialize<D>(d: D) -> Result<Field_, D::Error>
-    where
-        D: de::Deserializer<'de>,
-    {
-        d.deserialize_str(FieldVisitor_)
-    }
-}
-struct FieldVisitor_;
-impl<'de> de::Visitor<'de> for FieldVisitor_ {
-    type Value = Field_;
-    fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.write_str("string")
-    }
-    fn visit_str<E>(self, value: &str) -> Result<Field_, E>
-    where
-        E: de::Error,
-    {
-        let v = match value {
-            "type" => Field_::Type,
-            "time" => Field_::Time,
-            "uid" => Field_::Uid,
-            "sid" => Field_::Sid,
-            "tokenId" => Field_::TokenId,
-            "orgId" => Field_::OrgId,
-            "unsafeParams" => Field_::UnsafeParams,
-            "span" => Field_::Span,
-            _ => Field_::Unknown_,
-        };
-        Ok(v)
     }
 }

--- a/witchcraft-server/src/logging/api/user_id.rs
+++ b/witchcraft-server/src/logging/api/user_id.rs
@@ -1,5 +1,16 @@
-use conjure_object::serde::{ser, de};
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[derive(
+    Debug,
+    Clone,
+    conjure_object::serde::Deserialize,
+    conjure_object::serde::Serialize,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Default
+)]
+#[serde(crate = "conjure_object::serde", transparent)]
 pub struct UserId(pub String);
 impl std::fmt::Display for UserId {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -35,21 +46,5 @@ impl std::ops::DerefMut for UserId {
     #[inline]
     fn deref_mut(&mut self) -> &mut String {
         &mut self.0
-    }
-}
-impl ser::Serialize for UserId {
-    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
-    where
-        S: ser::Serializer,
-    {
-        self.0.serialize(s)
-    }
-}
-impl<'de> de::Deserialize<'de> for UserId {
-    fn deserialize<D>(d: D) -> Result<UserId, D::Error>
-    where
-        D: de::Deserializer<'de>,
-    {
-        de::Deserialize::deserialize(d).map(UserId)
     }
 }

--- a/witchcraft-server/src/logging/api/witchcraft_envelope_v1.rs
+++ b/witchcraft-server/src/logging/api/witchcraft_envelope_v1.rs
@@ -1,34 +1,54 @@
-use conjure_object::serde::{ser, de};
-use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use std::fmt;
 ///Wraps a log entry with metadata on where it is coming from and the source service that generated it.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+    Debug,
+    Clone,
+    conjure_object::serde::Serialize,
+    conjure_object::serde::Deserialize,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash
+)]
+#[serde(crate = "conjure_object::serde")]
 #[conjure_object::private::staged_builder::staged_builder]
 #[builder(crate = conjure_object::private::staged_builder, update, inline)]
 pub struct WitchcraftEnvelopeV1 {
     #[builder(into)]
+    #[serde(rename = "type")]
     type_: String,
     #[builder(into)]
+    #[serde(rename = "deployment")]
     deployment: String,
     #[builder(into)]
+    #[serde(rename = "environment")]
     environment: String,
     #[builder(into)]
+    #[serde(rename = "environmentId")]
     environment_id: String,
     #[builder(into)]
+    #[serde(rename = "host")]
     host: String,
     #[builder(into)]
+    #[serde(rename = "nodeId")]
     node_id: String,
     #[builder(into)]
+    #[serde(rename = "service")]
     service: String,
     #[builder(into)]
+    #[serde(rename = "serviceId")]
     service_id: String,
     #[builder(into)]
+    #[serde(rename = "stack")]
     stack: String,
     #[builder(into)]
+    #[serde(rename = "stackId")]
     stack_id: String,
     #[builder(into)]
+    #[serde(rename = "product")]
     product: String,
     #[builder(into)]
+    #[serde(rename = "productVersion")]
     product_version: String,
     #[builder(
         custom(
@@ -37,6 +57,7 @@ pub struct WitchcraftEnvelopeV1 {
             convert = |v|conjure_object::Any::new(v).expect("value failed to serialize")
         )
     )]
+    #[serde(rename = "payload")]
     payload: conjure_object::Any,
 }
 impl WitchcraftEnvelopeV1 {
@@ -104,219 +125,5 @@ impl WitchcraftEnvelopeV1 {
     #[inline]
     pub fn payload(&self) -> &conjure_object::Any {
         &self.payload
-    }
-}
-impl ser::Serialize for WitchcraftEnvelopeV1 {
-    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
-    where
-        S: ser::Serializer,
-    {
-        let size = 13usize;
-        let mut s = s.serialize_struct("WitchcraftEnvelopeV1", size)?;
-        s.serialize_field("type", &self.type_)?;
-        s.serialize_field("deployment", &self.deployment)?;
-        s.serialize_field("environment", &self.environment)?;
-        s.serialize_field("environmentId", &self.environment_id)?;
-        s.serialize_field("host", &self.host)?;
-        s.serialize_field("nodeId", &self.node_id)?;
-        s.serialize_field("service", &self.service)?;
-        s.serialize_field("serviceId", &self.service_id)?;
-        s.serialize_field("stack", &self.stack)?;
-        s.serialize_field("stackId", &self.stack_id)?;
-        s.serialize_field("product", &self.product)?;
-        s.serialize_field("productVersion", &self.product_version)?;
-        s.serialize_field("payload", &self.payload)?;
-        s.end()
-    }
-}
-impl<'de> de::Deserialize<'de> for WitchcraftEnvelopeV1 {
-    fn deserialize<D>(d: D) -> Result<WitchcraftEnvelopeV1, D::Error>
-    where
-        D: de::Deserializer<'de>,
-    {
-        d.deserialize_struct(
-            "WitchcraftEnvelopeV1",
-            &[
-                "type",
-                "deployment",
-                "environment",
-                "environmentId",
-                "host",
-                "nodeId",
-                "service",
-                "serviceId",
-                "stack",
-                "stackId",
-                "product",
-                "productVersion",
-                "payload",
-            ],
-            Visitor_,
-        )
-    }
-}
-struct Visitor_;
-impl<'de> de::Visitor<'de> for Visitor_ {
-    type Value = WitchcraftEnvelopeV1;
-    fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.write_str("map")
-    }
-    fn visit_map<A>(self, mut map_: A) -> Result<WitchcraftEnvelopeV1, A::Error>
-    where
-        A: de::MapAccess<'de>,
-    {
-        let mut type_ = None;
-        let mut deployment = None;
-        let mut environment = None;
-        let mut environment_id = None;
-        let mut host = None;
-        let mut node_id = None;
-        let mut service = None;
-        let mut service_id = None;
-        let mut stack = None;
-        let mut stack_id = None;
-        let mut product = None;
-        let mut product_version = None;
-        let mut payload = None;
-        while let Some(field_) = map_.next_key()? {
-            match field_ {
-                Field_::Type => type_ = Some(map_.next_value()?),
-                Field_::Deployment => deployment = Some(map_.next_value()?),
-                Field_::Environment => environment = Some(map_.next_value()?),
-                Field_::EnvironmentId => environment_id = Some(map_.next_value()?),
-                Field_::Host => host = Some(map_.next_value()?),
-                Field_::NodeId => node_id = Some(map_.next_value()?),
-                Field_::Service => service = Some(map_.next_value()?),
-                Field_::ServiceId => service_id = Some(map_.next_value()?),
-                Field_::Stack => stack = Some(map_.next_value()?),
-                Field_::StackId => stack_id = Some(map_.next_value()?),
-                Field_::Product => product = Some(map_.next_value()?),
-                Field_::ProductVersion => product_version = Some(map_.next_value()?),
-                Field_::Payload => payload = Some(map_.next_value()?),
-                Field_::Unknown_ => {
-                    map_.next_value::<de::IgnoredAny>()?;
-                }
-            }
-        }
-        let type_ = match type_ {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("type")),
-        };
-        let deployment = match deployment {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("deployment")),
-        };
-        let environment = match environment {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("environment")),
-        };
-        let environment_id = match environment_id {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("environmentId")),
-        };
-        let host = match host {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("host")),
-        };
-        let node_id = match node_id {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("nodeId")),
-        };
-        let service = match service {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("service")),
-        };
-        let service_id = match service_id {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("serviceId")),
-        };
-        let stack = match stack {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("stack")),
-        };
-        let stack_id = match stack_id {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("stackId")),
-        };
-        let product = match product {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("product")),
-        };
-        let product_version = match product_version {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("productVersion")),
-        };
-        let payload = match payload {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("payload")),
-        };
-        Ok(WitchcraftEnvelopeV1 {
-            type_,
-            deployment,
-            environment,
-            environment_id,
-            host,
-            node_id,
-            service,
-            service_id,
-            stack,
-            stack_id,
-            product,
-            product_version,
-            payload,
-        })
-    }
-}
-enum Field_ {
-    Type,
-    Deployment,
-    Environment,
-    EnvironmentId,
-    Host,
-    NodeId,
-    Service,
-    ServiceId,
-    Stack,
-    StackId,
-    Product,
-    ProductVersion,
-    Payload,
-    Unknown_,
-}
-impl<'de> de::Deserialize<'de> for Field_ {
-    fn deserialize<D>(d: D) -> Result<Field_, D::Error>
-    where
-        D: de::Deserializer<'de>,
-    {
-        d.deserialize_str(FieldVisitor_)
-    }
-}
-struct FieldVisitor_;
-impl<'de> de::Visitor<'de> for FieldVisitor_ {
-    type Value = Field_;
-    fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.write_str("string")
-    }
-    fn visit_str<E>(self, value: &str) -> Result<Field_, E>
-    where
-        E: de::Error,
-    {
-        let v = match value {
-            "type" => Field_::Type,
-            "deployment" => Field_::Deployment,
-            "environment" => Field_::Environment,
-            "environmentId" => Field_::EnvironmentId,
-            "host" => Field_::Host,
-            "nodeId" => Field_::NodeId,
-            "service" => Field_::Service,
-            "serviceId" => Field_::ServiceId,
-            "stack" => Field_::Stack,
-            "stackId" => Field_::StackId,
-            "product" => Field_::Product,
-            "productVersion" => Field_::ProductVersion,
-            "payload" => Field_::Payload,
-            _ => Field_::Unknown_,
-        };
-        Ok(v)
     }
 }

--- a/witchcraft-server/src/logging/api/wrapped_log_v1.rs
+++ b/witchcraft-server/src/logging/api/wrapped_log_v1.rs
@@ -1,26 +1,42 @@
-use conjure_object::serde::{ser, de};
-use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use std::fmt;
 ///Wraps a log entry with entity information.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+    Debug,
+    Clone,
+    conjure_object::serde::Serialize,
+    conjure_object::serde::Deserialize,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash
+)]
+#[serde(crate = "conjure_object::serde")]
 #[conjure_object::private::staged_builder::staged_builder]
 #[builder(crate = conjure_object::private::staged_builder, update, inline)]
 pub struct WrappedLogV1 {
     #[builder(into)]
+    #[serde(rename = "type")]
     type_: String,
     #[builder(custom(type = super::WrappedLogV1Payload, convert = Box::new))]
+    #[serde(rename = "payload")]
     payload: Box<super::WrappedLogV1Payload>,
     #[builder(into)]
+    #[serde(rename = "entityName")]
     entity_name: String,
     #[builder(into)]
+    #[serde(rename = "entityVersion")]
     entity_version: String,
     #[builder(default, into)]
+    #[serde(rename = "service", skip_serializing_if = "Option::is_none", default)]
     service: Option<String>,
     #[builder(default, into)]
+    #[serde(rename = "serviceId", skip_serializing_if = "Option::is_none", default)]
     service_id: Option<String>,
     #[builder(default, into)]
+    #[serde(rename = "stack", skip_serializing_if = "Option::is_none", default)]
     stack: Option<String>,
     #[builder(default, into)]
+    #[serde(rename = "stackId", skip_serializing_if = "Option::is_none", default)]
     stack_id: Option<String>,
 }
 impl WrappedLogV1 {
@@ -61,196 +77,5 @@ impl WrappedLogV1 {
     #[inline]
     pub fn stack_id(&self) -> Option<&str> {
         self.stack_id.as_ref().map(|o| &**o)
-    }
-}
-impl ser::Serialize for WrappedLogV1 {
-    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
-    where
-        S: ser::Serializer,
-    {
-        let mut size = 4usize;
-        let skip_service = self.service.is_none();
-        if !skip_service {
-            size += 1;
-        }
-        let skip_service_id = self.service_id.is_none();
-        if !skip_service_id {
-            size += 1;
-        }
-        let skip_stack = self.stack.is_none();
-        if !skip_stack {
-            size += 1;
-        }
-        let skip_stack_id = self.stack_id.is_none();
-        if !skip_stack_id {
-            size += 1;
-        }
-        let mut s = s.serialize_struct("WrappedLogV1", size)?;
-        s.serialize_field("type", &self.type_)?;
-        s.serialize_field("payload", &self.payload)?;
-        s.serialize_field("entityName", &self.entity_name)?;
-        s.serialize_field("entityVersion", &self.entity_version)?;
-        if skip_service {
-            s.skip_field("service")?;
-        } else {
-            s.serialize_field("service", &self.service)?;
-        }
-        if skip_service_id {
-            s.skip_field("serviceId")?;
-        } else {
-            s.serialize_field("serviceId", &self.service_id)?;
-        }
-        if skip_stack {
-            s.skip_field("stack")?;
-        } else {
-            s.serialize_field("stack", &self.stack)?;
-        }
-        if skip_stack_id {
-            s.skip_field("stackId")?;
-        } else {
-            s.serialize_field("stackId", &self.stack_id)?;
-        }
-        s.end()
-    }
-}
-impl<'de> de::Deserialize<'de> for WrappedLogV1 {
-    fn deserialize<D>(d: D) -> Result<WrappedLogV1, D::Error>
-    where
-        D: de::Deserializer<'de>,
-    {
-        d.deserialize_struct(
-            "WrappedLogV1",
-            &[
-                "type",
-                "payload",
-                "entityName",
-                "entityVersion",
-                "service",
-                "serviceId",
-                "stack",
-                "stackId",
-            ],
-            Visitor_,
-        )
-    }
-}
-struct Visitor_;
-impl<'de> de::Visitor<'de> for Visitor_ {
-    type Value = WrappedLogV1;
-    fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.write_str("map")
-    }
-    fn visit_map<A>(self, mut map_: A) -> Result<WrappedLogV1, A::Error>
-    where
-        A: de::MapAccess<'de>,
-    {
-        let mut type_ = None;
-        let mut payload = None;
-        let mut entity_name = None;
-        let mut entity_version = None;
-        let mut service = None;
-        let mut service_id = None;
-        let mut stack = None;
-        let mut stack_id = None;
-        while let Some(field_) = map_.next_key()? {
-            match field_ {
-                Field_::Type => type_ = Some(map_.next_value()?),
-                Field_::Payload => payload = Some(map_.next_value()?),
-                Field_::EntityName => entity_name = Some(map_.next_value()?),
-                Field_::EntityVersion => entity_version = Some(map_.next_value()?),
-                Field_::Service => service = Some(map_.next_value()?),
-                Field_::ServiceId => service_id = Some(map_.next_value()?),
-                Field_::Stack => stack = Some(map_.next_value()?),
-                Field_::StackId => stack_id = Some(map_.next_value()?),
-                Field_::Unknown_ => {
-                    map_.next_value::<de::IgnoredAny>()?;
-                }
-            }
-        }
-        let type_ = match type_ {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("type")),
-        };
-        let payload = match payload {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("payload")),
-        };
-        let entity_name = match entity_name {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("entityName")),
-        };
-        let entity_version = match entity_version {
-            Some(v) => v,
-            None => return Err(de::Error::missing_field("entityVersion")),
-        };
-        let service = match service {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let service_id = match service_id {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let stack = match stack {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        let stack_id = match stack_id {
-            Some(v) => v,
-            None => Default::default(),
-        };
-        Ok(WrappedLogV1 {
-            type_,
-            payload,
-            entity_name,
-            entity_version,
-            service,
-            service_id,
-            stack,
-            stack_id,
-        })
-    }
-}
-enum Field_ {
-    Type,
-    Payload,
-    EntityName,
-    EntityVersion,
-    Service,
-    ServiceId,
-    Stack,
-    StackId,
-    Unknown_,
-}
-impl<'de> de::Deserialize<'de> for Field_ {
-    fn deserialize<D>(d: D) -> Result<Field_, D::Error>
-    where
-        D: de::Deserializer<'de>,
-    {
-        d.deserialize_str(FieldVisitor_)
-    }
-}
-struct FieldVisitor_;
-impl<'de> de::Visitor<'de> for FieldVisitor_ {
-    type Value = Field_;
-    fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.write_str("string")
-    }
-    fn visit_str<E>(self, value: &str) -> Result<Field_, E>
-    where
-        E: de::Error,
-    {
-        let v = match value {
-            "type" => Field_::Type,
-            "payload" => Field_::Payload,
-            "entityName" => Field_::EntityName,
-            "entityVersion" => Field_::EntityVersion,
-            "service" => Field_::Service,
-            "serviceId" => Field_::ServiceId,
-            "stack" => Field_::Stack,
-            "stackId" => Field_::StackId,
-            _ => Field_::Unknown_,
-        };
-        Ok(v)
     }
 }

--- a/witchcraft-server/src/minidump/mod.rs
+++ b/witchcraft-server/src/minidump/mod.rs
@@ -42,11 +42,18 @@ pub async fn init() -> Result<(), Error> {
         .stdin(Stdio::piped())
         .spawn()
         .map_err(Error::internal_safe)?;
+    let child_pid = child.id();
 
     // Ensure that the child's stdin says open until this process exits since that's how it detects the parent exiting.
     mem::forget(child.stdin);
 
     let client = connect().await?;
+
+    // Enable the child to trace us in restricted ptrace environments
+    let ret = unsafe { libc::prctl(libc::PR_SET_PTRACER, child_pid as libc::c_long) };
+    if ret != 0 {
+        return Err(Error::internal_safe(io::Error::last_os_error()));
+    }
 
     let guard = CrashHandler::attach(unsafe {
         crash_handler::make_crash_event(move |context| {


### PR DESCRIPTION
## Before this PR
In environments running in restricted ptrace mode (/proc/sys/kernel/yama/ptrace_scope set to 1), the child dumper process was not able to trace the parent. This includes circle, so the thread dump diagnostic was never actually tested.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Fixed minidumps in restricted ptrace environments.
==COMMIT_MSG==

https://man7.org/linux/man-pages/man2/pr_set_ptracer.2const.html

Fixes #74 