### PR TITLE
Fix build on macOS

### DIFF
--- a/changelog/@unreleased/pr-230.v2.yml
+++ b/changelog/@unreleased/pr-230.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fixed the build on macOS.
+  links:
+  - https://github.com/palantir/witchcraft-rust-server/pull/230

--- a/witchcraft-server/src/minidump/mod.rs
+++ b/witchcraft-server/src/minidump/mod.rs
@@ -42,17 +42,16 @@ pub async fn init() -> Result<(), Error> {
         .stdin(Stdio::piped())
         .spawn()
         .map_err(Error::internal_safe)?;
-    let child_pid = child.id();
-
-    // Ensure that the child's stdin says open until this process exits since that's how it detects the parent exiting.
-    mem::forget(child.stdin);
 
     let client = connect().await?;
 
-    // Enable the child to trace us in restricted ptrace environments
-    let ret = unsafe { libc::prctl(libc::PR_SET_PTRACER, child_pid as libc::c_long) };
-    if ret != 0 {
-        return Err(Error::internal_safe(io::Error::last_os_error()));
+    // Enable the child to trace us in restricted ptrace linux environments
+    #[cfg(target_os = "linux")]
+    {
+        let ret = unsafe { libc::prctl(libc::PR_SET_PTRACER, child.id() as libc::c_long) };
+        if ret != 0 {
+            return Err(Error::internal_safe(io::Error::last_os_error()));
+        }
     }
 
     let guard = CrashHandler::attach(unsafe {
@@ -63,6 +62,9 @@ pub async fn init() -> Result<(), Error> {
     })
     .map_err(Error::internal_safe)?;
     mem::forget(guard);
+
+    // Ensure that the child's stdin says open until this process exits since that's how it detects the parent exiting.
+    mem::forget(child.stdin);
 
     Ok(())
 }


### PR DESCRIPTION
## Before this PR
The build would break on any non-Linux platform:

```
error[E0425]: cannot find function `prctl` in crate `libc`
  --> /witchcraft-server-5.1.0/src/minidump/mod.rs:53:30
   |
53 |     let ret = unsafe { libc::prctl(libc::PR_SET_PTRACER, child_pid as libc::c_long) };
   |                              ^^^^^ not found in `libc`

error[E0425]: cannot find value `PR_SET_PTRACER` in crate `libc`
  --> /witchcraft-server-5.1.0/src/minidump/mod.rs:53:42
   |
53 |     let ret = unsafe { libc::prctl(libc::PR_SET_PTRACER, child_pid as libc::c_long) };
   |                                          ^^^^^^^^^^^^^^ not found in `libc`
```

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Fixed the build on macOS.
==COMMIT_MSG==