### PR TITLE
Fix heap profile logic on macOS

### DIFF
--- a/changelog/@unreleased/pr-231.v2.yml
+++ b/changelog/@unreleased/pr-231.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fixed heap profile logic on macOS
+  links:
+  - https://github.com/palantir/witchcraft-rust-server/pull/231

--- a/witchcraft-server/src/debug/heap_profile.rs
+++ b/witchcraft-server/src/debug/heap_profile.rs
@@ -22,12 +22,18 @@ use std::{
     fs,
 };
 use tempfile::NamedTempFile;
-use witchcraft_log::info;
+use witchcraft_log::{info, warn};
 use witchcraft_server_config::runtime::RuntimeConfig;
 
 #[no_mangle]
 #[allow(non_upper_case_globals)]
+#[cfg(target_os = "linux")]
 static malloc_conf: &c_char = unsafe { &*c"prof:true,prof_active:false".as_ptr() };
+
+#[no_mangle]
+#[allow(non_upper_case_globals)]
+#[cfg(target_os = "macos")]
+static _rjem_malloc_conf: &c_char = unsafe { &*c"prof:true,prof_active:false".as_ptr() };
 
 pub fn init<R>(runtime: &Refreshable<R, Error>)
 where
@@ -37,9 +43,10 @@ where
         .map(|r| r.as_ref().diagnostics().jemalloc().prof_active())
         .subscribe(|active| {
             info!("setting prof.active", safe: { value: active });
-            unsafe {
+            if let Err(e) = unsafe {
                 tikv_jemalloc_ctl::raw::write::<bool>(c"prof.active".to_bytes_with_nul(), *active)
-                    .unwrap();
+            } {
+                warn!("error setting prof.active", error: Error::internal_safe(e));
             }
         })
         .leak();
@@ -48,12 +55,13 @@ where
         .map(|r| r.as_ref().diagnostics().jemalloc().lg_prof_sample())
         .subscribe(|lg_prof_sample| {
             info!("setting prof.reset", safe: { value: lg_prof_sample });
-            unsafe {
+            if let Err(e) = unsafe {
                 tikv_jemalloc_ctl::raw::write::<usize>(
                     c"prof.reset".to_bytes_with_nul(),
                     *lg_prof_sample,
                 )
-                .unwrap();
+            } {
+                warn!("error setting prof.reset", error: Error::internal_safe(e));
             }
         })
         .leak();


### PR DESCRIPTION
## Before this PR
The heap profile diagnostic had 2 problems:

* It panicked if it couldn't set the prof.active or prof.reset ctrls, but those aren't available if profiling is disabled via malloc conf.
* The magic `malloc_conf` symbol is actually called `_rjem_malloc_conf` on macOS so profiling wasn't enabled there.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Fixed heap profile logic on macOS
==COMMIT_MSG==

We now conditionally define the appropriate malloc conf static. We also just log a warning instead of panicking if the ctrls can't be set (even with the first fix you can forcibly disable profiling with e.g. the `MALLOC_CONF` environment variable).

