### PR TITLE
Don't call PR_SET_PTRACER unnecessarily

### DIFF
--- a/changelog/@unreleased/pr-232.v2.yml
+++ b/changelog/@unreleased/pr-232.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Only set the ptracer in restricted ptrace environments.
+  links:
+  - https://github.com/palantir/witchcraft-rust-server/pull/232

--- a/witchcraft-server-macros/Cargo.toml
+++ b/witchcraft-server-macros/Cargo.toml
@@ -14,8 +14,3 @@ proc-macro = true
 proc-macro2 = "1"
 quote = "1"
 syn = { version = "2", features = ["full"] }
-
-[dev-dependencies]
-conjure-error = "4"
-refreshable = "2"
-witchcraft-server = { version = "5.2.0", path = "../witchcraft-server" }

--- a/witchcraft-server-macros/src/lib.rs
+++ b/witchcraft-server-macros/src/lib.rs
@@ -25,7 +25,7 @@ use syn::{Error, ItemFn};
 ///
 /// # Examples
 ///
-/// ```no_run
+/// ```ignore
 /// use conjure_error::Error;
 /// use witchcraft_server::config::install::InstallConfig;
 /// use witchcraft_server::config::runtime::RuntimeConfig;
@@ -45,7 +45,7 @@ use syn::{Error, ItemFn};
 ///
 /// Expands to:
 ///
-/// ```no_run
+/// ```ignore
 /// use conjure_error::Error;
 /// use witchcraft_server::config::install::InstallConfig;
 /// use witchcraft_server::config::runtime::RuntimeConfig;

--- a/witchcraft-server/src/minidump/mod.rs
+++ b/witchcraft-server/src/minidump/mod.rs
@@ -47,12 +47,7 @@ pub async fn init() -> Result<(), Error> {
 
     // Enable the child to trace us in restricted ptrace linux environments
     #[cfg(target_os = "linux")]
-    {
-        let ret = unsafe { libc::prctl(libc::PR_SET_PTRACER, child.id() as libc::c_long) };
-        if ret != 0 {
-            return Err(Error::internal_safe(io::Error::last_os_error()));
-        }
-    }
+    handle_restricted_ptrace(child.id())?;
 
     let guard = CrashHandler::attach(unsafe {
         crash_handler::make_crash_event(move |context| {
@@ -65,6 +60,34 @@ pub async fn init() -> Result<(), Error> {
 
     // Ensure that the child's stdin says open until this process exits since that's how it detects the parent exiting.
     mem::forget(child.stdin);
+
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn handle_restricted_ptrace(child: u32) -> Result<(), Error> {
+    let ptrace_scope = match fs::read_to_string("/proc/sys/kernel/yama/ptrace_scope") {
+        Ok(buf) => buf,
+        Err(e) => {
+            debug!("error reading ptrace_scope", error: Error::internal_safe(e));
+            return Ok(());
+        }
+    };
+
+    if ptrace_scope != "1" {
+        debug!(
+            "ptrace scope not restricted, skipping PR_SET_PTRACER",
+            safe: {
+                scope: ptrace_scope
+            }
+        );
+        return Ok(());
+    }
+
+    let ret = unsafe { libc::prctl(libc::PR_SET_PTRACER, child as libc::c_ulong) };
+    if ret != 0 {
+        return Err(Error::internal_safe(io::Error::last_os_error()));
+    }
 
     Ok(())
 }

--- a/witchcraft-server/src/minidump/mod.rs
+++ b/witchcraft-server/src/minidump/mod.rs
@@ -74,7 +74,7 @@ fn handle_restricted_ptrace(child: u32) -> Result<(), Error> {
         }
     };
 
-    if ptrace_scope != "1" {
+    if ptrace_scope.trim() != "1" {
         debug!(
             "ptrace scope not restricted, skipping PR_SET_PTRACER",
             safe: {

--- a/witchcraft-server/src/minidump/mod.rs
+++ b/witchcraft-server/src/minidump/mod.rs
@@ -64,12 +64,17 @@ pub async fn init() -> Result<(), Error> {
     Ok(())
 }
 
+/// If the server is running in a Linux environment with the Yama security module enabled and configured with the
+/// ptrace scope set to restricted (i.e. 1), we need to explicitly tell the kernel that the child process is allowed
+/// to trace us.
+///
+/// https://man7.org/linux/man-pages/man2/pr_set_ptracer.2const.html
 #[cfg(target_os = "linux")]
 fn handle_restricted_ptrace(child: u32) -> Result<(), Error> {
     let ptrace_scope = match fs::read_to_string("/proc/sys/kernel/yama/ptrace_scope") {
         Ok(buf) => buf,
         Err(e) => {
-            debug!("error reading ptrace_scope", error: Error::internal_safe(e));
+            debug!("error reading ptrace_scope, assuming yama not enabled", error: Error::internal_safe(e));
             return Ok(());
         }
     };


### PR DESCRIPTION
## Before this PR
`PR_SET_PTRACER` only has an effect in restricted ptrace environments (Linux kernels with yama loaded and ptrace_scope set to 1). We would previously unconditionally try to call it, which would fail with EINVAL in environments that don't have yama, like WSL2.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Only set the ptracer in restricted ptrace environments.
==COMMIT_MSG==

