### PR TITLE
Initialize minidump health state to Healthy

### DIFF
--- a/changelog/@unreleased/pr-235.v2.yml
+++ b/changelog/@unreleased/pr-235.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Initialize minidump health state to Healthy
+  links:
+  - https://github.com/palantir/witchcraft-rust-server/pull/235/

--- a/witchcraft-server/src/health/minidump.rs
+++ b/witchcraft-server/src/health/minidump.rs
@@ -1,18 +1,18 @@
-use std::sync::{
-    atomic::{AtomicBool, Ordering},
-    Arc,
-};
+use std::sync::{atomic::{AtomicBool, Ordering}, Arc, Mutex};
+use std::time::{Duration, Instant};
 
 use super::{HealthCheck, HealthCheckResult, HealthState};
 
 /// A health check which reports an error state if minidump initialization has not completed successfully.
 pub struct MinidumpHealthCheck {
     minidump_ok: Arc<AtomicBool>,
+    first_unhealthy_time: Arc<Mutex<Option<Instant>>>,
 }
 
 impl MinidumpHealthCheck {
     pub fn new(minidump_ok: Arc<AtomicBool>) -> Self {
-        MinidumpHealthCheck { minidump_ok }
+        MinidumpHealthCheck { minidump_ok,
+        first_unhealthy_time: Arc::new(Mutex::new(None)) }
     }
 }
 
@@ -23,12 +23,23 @@ impl HealthCheck for MinidumpHealthCheck {
 
     fn result(&self) -> HealthCheckResult {
         if self.minidump_ok.load(Ordering::Relaxed) {
+            let mut start_time = self.first_unhealthy_time.lock().unwrap();
+            *start_time = None;
+            return HealthCheckResult::builder().state(HealthState::Healthy).build();
+        }
+
+        let mut start_time = self.first_unhealthy_time.lock().unwrap();
+
+        let elapsed = start_time.get_or_insert_with(Instant::now).elapsed();
+
+        if elapsed > Duration::from_secs(300) {
             HealthCheckResult::builder()
-                .state(HealthState::Healthy)
+                .state(HealthState::Error)
+                .message("minidump client could not connect to server for over 5 minutes".to_string())
                 .build()
         } else {
             HealthCheckResult::builder()
-                .state(HealthState::Error)
+                .state(HealthState::Warning)
                 .message("minidump client has not connected to server".to_string())
                 .build()
         }

--- a/witchcraft-server/src/health/minidump.rs
+++ b/witchcraft-server/src/health/minidump.rs
@@ -1,4 +1,7 @@
-use std::sync::{atomic::{AtomicBool, Ordering}, Arc, Mutex};
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc, Mutex,
+};
 use std::time::{Duration, Instant};
 
 use super::{HealthCheck, HealthCheckResult, HealthState};
@@ -11,8 +14,10 @@ pub struct MinidumpHealthCheck {
 
 impl MinidumpHealthCheck {
     pub fn new(minidump_ok: Arc<AtomicBool>) -> Self {
-        MinidumpHealthCheck { minidump_ok,
-        first_unhealthy_time: Arc::new(Mutex::new(None)) }
+        MinidumpHealthCheck {
+            minidump_ok,
+            first_unhealthy_time: Arc::new(Mutex::new(None)),
+        }
     }
 }
 
@@ -25,7 +30,9 @@ impl HealthCheck for MinidumpHealthCheck {
         if self.minidump_ok.load(Ordering::Relaxed) {
             let mut start_time = self.first_unhealthy_time.lock().unwrap();
             *start_time = None;
-            return HealthCheckResult::builder().state(HealthState::Healthy).build();
+            return HealthCheckResult::builder()
+                .state(HealthState::Healthy)
+                .build();
         }
 
         let mut start_time = self.first_unhealthy_time.lock().unwrap();
@@ -35,7 +42,9 @@ impl HealthCheck for MinidumpHealthCheck {
         if elapsed > Duration::from_secs(300) {
             HealthCheckResult::builder()
                 .state(HealthState::Error)
-                .message("minidump client could not connect to server for over 5 minutes".to_string())
+                .message(
+                    "minidump client could not connect to server for over 5 minutes".to_string(),
+                )
                 .build()
         } else {
             HealthCheckResult::builder()

--- a/witchcraft-server/src/health/minidump.rs
+++ b/witchcraft-server/src/health/minidump.rs
@@ -1,23 +1,18 @@
 use std::sync::{
     atomic::{AtomicBool, Ordering},
-    Arc, Mutex,
+    Arc,
 };
-use std::time::{Duration, Instant};
 
 use super::{HealthCheck, HealthCheckResult, HealthState};
 
 /// A health check which reports an error state if minidump initialization has not completed successfully.
 pub struct MinidumpHealthCheck {
     minidump_ok: Arc<AtomicBool>,
-    first_unhealthy_time: Arc<Mutex<Option<Instant>>>,
 }
 
 impl MinidumpHealthCheck {
     pub fn new(minidump_ok: Arc<AtomicBool>) -> Self {
-        MinidumpHealthCheck {
-            minidump_ok,
-            first_unhealthy_time: Arc::new(Mutex::new(None)),
-        }
+        MinidumpHealthCheck { minidump_ok }
     }
 }
 
@@ -28,27 +23,12 @@ impl HealthCheck for MinidumpHealthCheck {
 
     fn result(&self) -> HealthCheckResult {
         if self.minidump_ok.load(Ordering::Relaxed) {
-            let mut start_time = self.first_unhealthy_time.lock().unwrap();
-            *start_time = None;
-            return HealthCheckResult::builder()
-                .state(HealthState::Healthy)
-                .build();
-        }
-
-        let mut start_time = self.first_unhealthy_time.lock().unwrap();
-
-        let elapsed = start_time.get_or_insert_with(Instant::now).elapsed();
-
-        if elapsed > Duration::from_secs(600) {
             HealthCheckResult::builder()
-                .state(HealthState::Error)
-                .message(
-                    "minidump client could not connect to server for over 10 minutes".to_string(),
-                )
+                .state(HealthState::Healthy)
                 .build()
         } else {
             HealthCheckResult::builder()
-                .state(HealthState::Warning)
+                .state(HealthState::Error)
                 .message("minidump client has not connected to server".to_string())
                 .build()
         }

--- a/witchcraft-server/src/health/minidump.rs
+++ b/witchcraft-server/src/health/minidump.rs
@@ -39,11 +39,11 @@ impl HealthCheck for MinidumpHealthCheck {
 
         let elapsed = start_time.get_or_insert_with(Instant::now).elapsed();
 
-        if elapsed > Duration::from_secs(300) {
+        if elapsed > Duration::from_secs(600) {
             HealthCheckResult::builder()
                 .state(HealthState::Error)
                 .message(
-                    "minidump client could not connect to server for over 5 minutes".to_string(),
+                    "minidump client could not connect to server for over 10 minutes".to_string(),
                 )
                 .build()
         } else {

--- a/witchcraft-server/src/lib.rs
+++ b/witchcraft-server/src/lib.rs
@@ -447,7 +447,7 @@ where
 
     info!("server starting");
 
-    let minidump_ok = Arc::new(AtomicBool::new(false));
+    let minidump_ok = Arc::new(AtomicBool::new(true));
     let minidump_ok_cloned = minidump_ok.clone();
     handle.spawn(minidump::init().then(|result| async move {
         minidump_ok_cloned.store(result.is_ok(), Ordering::Relaxed);


### PR DESCRIPTION
## Before this PR
Health checks fail during Blue/Green upgrades if minidump is not up. B/G should not fail on minidump startup.
## After this PR
We initialize the `minidump_ok` state to `true` meaning minidump will report `Healthy` if it hasn't come up yet and only `Error` if the connection fails after it's been healthy.

==COMMIT_MSG==
==COMMIT_MSG==