### PR TITLE
Set jemalloc as the global allocator

### DIFF
--- a/changelog/@unreleased/pr-237.v2.yml
+++ b/changelog/@unreleased/pr-237.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Jemalloc is now registered as the Rust global allocator.
+  links:
+  - https://github.com/palantir/witchcraft-rust-server/pull/237

--- a/witchcraft-server/src/lib.rs
+++ b/witchcraft-server/src/lib.rs
@@ -356,6 +356,10 @@ mod status;
 pub mod tls;
 mod witchcraft;
 
+#[cfg(feature = "jemalloc")]
+#[global_allocator]
+static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 /// Initializes a Witchcraft server.
 ///
 /// `init` is invoked with the parsed install and runtime configs as well as the [`Witchcraft`] context object. It


### PR DESCRIPTION
## Before this PR
On the platforms we care about (Linux and macOS), Jemalloc replaced the system malloc, but Rust allocations were still performed through the standard libc allocator APIs.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Jemalloc is now registered as the Rust global allocator.
==COMMIT_MSG==

The implementation is slightly more efficient by using some of jemalloc's extended APIs.
