### PR TITLE
Make the minidump unix socket dir configurable

### DIFF
--- a/changelog/@unreleased/pr-247.v2.yml
+++ b/changelog/@unreleased/pr-247.v2.yml
@@ -1,0 +1,6 @@
+type: feature
+feature:
+  description: Added configuration options to disable the minidumper and configure
+    its socket dir.
+  links:
+  - https://github.com/palantir/witchcraft-rust-server/pull/247

--- a/witchcraft-server-config/src/install/de.rs
+++ b/witchcraft-server-config/src/install/de.rs
@@ -27,6 +27,7 @@ pub struct InstallConfig {
     pub context_path: Option<String>,
     pub use_console_log: Option<bool>,
     pub server: Option<super::ServerConfig>,
+    pub minidump: Option<super::MinidumpConfig>,
 }
 
 #[derive(Deserialize)]
@@ -57,4 +58,11 @@ pub struct ServerConfig {
     pub http2: Option<bool>,
     #[serde(default, with = "humantime_serde")]
     pub idle_connection_timeout: Option<Duration>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct MinidumpConfig {
+    pub enabled: Option<bool>,
+    pub socket_dir: Option<PathBuf>,
 }

--- a/witchcraft-server-config/src/install/mod.rs
+++ b/witchcraft-server-config/src/install/mod.rs
@@ -482,6 +482,8 @@ impl<'de> Deserialize<'de> for MinidumpConfig {
 impl MinidumpConfig {
     /// Determines if the server will spawn the minidump sidecar.
     ///
+    /// The sidecar is required for the thread dump diagnostic and crash reports.
+    ///
     /// Defaults to `true`.
     #[inline]
     pub fn enabled(&self) -> bool {

--- a/witchcraft-server-config/src/install/mod.rs
+++ b/witchcraft-server-config/src/install/mod.rs
@@ -44,6 +44,8 @@ pub struct InstallConfig {
     use_console_log: bool,
     #[builder(default)]
     server: ServerConfig,
+    #[builder(default)]
+    minidump: MinidumpConfig,
 }
 
 impl Validate for InstallConfig {
@@ -90,7 +92,9 @@ impl<'de> Deserialize<'de> for InstallConfig {
         if let Some(server) = raw.server {
             builder = builder.server(server);
         }
-
+        if let Some(minidump) = raw.minidump {
+            builder = builder.minidump(minidump);
+        }
         builder.build().map_err(Error::custom)
     }
 }
@@ -174,6 +178,12 @@ impl InstallConfig {
     #[inline]
     pub fn server(&self) -> &ServerConfig {
         &self.server
+    }
+
+    /// Returns minidump settings.
+    #[inline]
+    pub fn minidump(&self) -> &MinidumpConfig {
+        &self.minidump
     }
 }
 
@@ -432,5 +442,57 @@ impl ServerConfig {
     #[inline]
     pub fn idle_connection_timeout(&self) -> Option<Duration> {
         self.idle_connection_timeout
+    }
+}
+
+/// Minidump configuration.
+#[derive(Clone, PartialEq, Debug)]
+#[staged_builder]
+pub struct MinidumpConfig {
+    #[builder(default = true)]
+    enabled: bool,
+    #[builder(into, default = PathBuf::from("var/data/tmp"))]
+    socket_dir: PathBuf,
+}
+
+impl Default for MinidumpConfig {
+    #[inline]
+    fn default() -> Self {
+        MinidumpConfig::builder().build()
+    }
+}
+
+impl<'de> Deserialize<'de> for MinidumpConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let raw = de::MinidumpConfig::deserialize(deserializer)?;
+        let mut builder = MinidumpConfig::builder();
+        if let Some(enabled) = raw.enabled {
+            builder = builder.enabled(enabled);
+        }
+        if let Some(socket_dir) = raw.socket_dir {
+            builder = builder.socket_dir(socket_dir);
+        }
+        Ok(builder.build())
+    }
+}
+
+impl MinidumpConfig {
+    /// Determines if the server will spawn the minidump sidecar.
+    ///
+    /// Defaults to `true`.
+    #[inline]
+    pub fn enabled(&self) -> bool {
+        self.enabled
+    }
+
+    /// Returns the directory in which the minidump Unix socket will be placed.
+    ///
+    /// Defaults to `var/data/tmp`.
+    #[inline]
+    pub fn socket_dir(&self) -> &Path {
+        &self.socket_dir
     }
 }

--- a/witchcraft-server/Cargo.toml
+++ b/witchcraft-server/Cargo.toml
@@ -32,7 +32,6 @@ default = ["jemalloc"]
 jemalloc = ["dep:tikv-jemalloc-ctl", "dep:tikv-jemallocator"]
 
 [dependencies]
-addr2line = "0.25"
 arc-swap = "1"
 async-compression = { version = "0.4", features = ["tokio", "gzip"] }
 async-trait = "0.1"
@@ -73,6 +72,7 @@ rand = "0.9"
 refreshable = "2"
 regex = "1"
 rustls-pemfile = "2"
+rustls-pki-types = "1.11.0"
 rustls-webpki = "0.103"
 serde-encrypted-value = "1.0"
 serde-file-value = "0.1"
@@ -115,7 +115,6 @@ witchcraft-metrics = "1"
 witchcraft-server-config = { version = "5.5.0", path = "../witchcraft-server-config" }
 witchcraft-server-macros = { version = "5.5.0", path = "../witchcraft-server-macros" }
 zipkin = "1.0"
-rustls-pki-types = "1.11.0"
 
 [dev-dependencies]
 tempfile = "3"

--- a/witchcraft-server/src/debug/thread_dump.rs
+++ b/witchcraft-server/src/debug/thread_dump.rs
@@ -23,7 +23,7 @@ use std::fs;
 use std::io::Cursor;
 use std::os::unix::prelude::{OsStrExt, OsStringExt};
 use std::os::unix::process;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tempfile::NamedTempFile;
 use tokio::runtime::Handle;
 use witchcraft_log::error;
@@ -31,7 +31,17 @@ use witchcraft_log::error;
 /// A diagnostic which returns a stack trace of every thread in the server.
 ///
 /// It is only supported on Linux.
-pub struct ThreadDumpDiagnostic;
+pub struct ThreadDumpDiagnostic {
+    socket_dir: PathBuf,
+}
+
+impl ThreadDumpDiagnostic {
+    pub fn new(socket_dir: &Path) -> Self {
+        ThreadDumpDiagnostic {
+            socket_dir: socket_dir.to_owned(),
+        }
+    }
+}
 
 impl Diagnostic for ThreadDumpDiagnostic {
     fn type_(&self) -> &str {
@@ -50,7 +60,7 @@ impl Diagnostic for ThreadDumpDiagnostic {
         let target_file = NamedTempFile::new_in("var/data/tmp").map_err(Error::internal_safe)?;
         let handle = Handle::current();
 
-        let client = handle.block_on(minidump::connect())?;
+        let client = handle.block_on(minidump::connect(&self.socket_dir))?;
         client
             .send_message(0, target_file.path().as_os_str().as_bytes())
             .map_err(Error::internal_safe)?;

--- a/witchcraft-server/src/lib.rs
+++ b/witchcraft-server/src/lib.rs
@@ -441,6 +441,10 @@ where
     let runtime_config = load_runtime(&handle, &runtime_config_ok)?;
 
     let metrics = Arc::new(MetricRegistry::new());
+    let host_metrics = Arc::new(HostMetricsRegistry::new());
+    let health_checks = Arc::new(HealthCheckRegistry::new(&handle));
+    let readiness_checks = Arc::new(ReadinessCheckRegistry::new());
+    let diagnostics = Arc::new(DiagnosticRegistry::new());
 
     let loggers = handle.block_on(logging::init(
         &metrics,
@@ -451,28 +455,27 @@ where
 
     info!("server starting");
 
-    let minidump_ok = Arc::new(AtomicBool::new(true));
-    let minidump_ok_cloned = minidump_ok.clone();
-    handle.spawn(minidump::init().then(|result| async move {
-        minidump_ok_cloned.store(result.is_ok(), Ordering::Relaxed);
-        if let Err(e) = result {
-            error!("error during minidump init", error: e)
-        }
-    }));
+    if install_config.as_ref().minidump().enabled() {
+        let minidump_ok = Arc::new(AtomicBool::new(true));
+        let minidump_ok_cloned = minidump_ok.clone();
+        handle.spawn(minidump::init().then(|result| async move {
+            minidump_ok_cloned.store(result.is_ok(), Ordering::Relaxed);
+            if let Err(e) = result {
+                error!("error during minidump init", error: e)
+            }
+        }));
+
+        health_checks.register(MinidumpHealthCheck::new(minidump_ok));
+        #[cfg(target_os = "linux")]
+        diagnostics.register(ThreadDumpDiagnostic);
+    }
 
     metrics::init(&metrics);
 
-    let host_metrics = Arc::new(HostMetricsRegistry::new());
-
-    let health_checks = Arc::new(HealthCheckRegistry::new(&handle));
     health_checks.register(ServiceDependencyHealthCheck::new(&host_metrics));
     health_checks.register(PanicsHealthCheck::new());
     health_checks.register(ConfigReloadHealthCheck::new(runtime_config_ok));
-    health_checks.register(MinidumpHealthCheck::new(minidump_ok));
 
-    let readiness_checks = Arc::new(ReadinessCheckRegistry::new());
-
-    let diagnostics = Arc::new(DiagnosticRegistry::new());
     diagnostics.register(MetricNamesDiagnostic::new(&metrics));
     #[cfg(feature = "jemalloc")]
     {
@@ -480,9 +483,8 @@ where
         heap_profile::init(&runtime_config);
         diagnostics.register(HeapProfileDiagnostic);
     }
-    #[cfg(target_os = "linux")]
-    diagnostics.register(ThreadDumpDiagnostic);
     diagnostics.register(DiagnosticTypesDiagnostic::new(Arc::downgrade(&diagnostics)));
+
     let client_factory = ClientFactory::builder()
         .config(runtime_config.map(|c| c.as_ref().service_discovery().clone()))
         .user_agent(UserAgent::new(Agent::new(

--- a/witchcraft-server/src/lib.rs
+++ b/witchcraft-server/src/lib.rs
@@ -300,7 +300,6 @@ use debug::endpoint::DebugResource;
 use debug::endpoint::DebugServiceEndpoints;
 #[cfg(feature = "jemalloc")]
 use debug::heap_profile::{self, HeapProfileDiagnostic};
-use futures::FutureExt;
 use futures_util::{stream, Stream, StreamExt};
 use refreshable::Refreshable;
 use serde::de::DeserializeOwned;
@@ -457,17 +456,22 @@ where
 
     if install_config.as_ref().minidump().enabled() {
         let minidump_ok = Arc::new(AtomicBool::new(true));
-        let minidump_ok_cloned = minidump_ok.clone();
-        handle.spawn(minidump::init().then(|result| async move {
-            minidump_ok_cloned.store(result.is_ok(), Ordering::Relaxed);
-            if let Err(e) = result {
-                error!("error during minidump init", error: e)
+        let socket_dir = install_config.as_ref().minidump().socket_dir();
+        handle.spawn({
+            let minidump_ok = minidump_ok.clone();
+            let socket_dir = socket_dir.to_owned();
+            async move {
+                let result = minidump::init(&socket_dir).await;
+                minidump_ok.store(result.is_ok(), Ordering::Relaxed);
+                if let Err(e) = result {
+                    error!("error during minidump init", error: e)
+                }
             }
-        }));
+        });
 
         health_checks.register(MinidumpHealthCheck::new(minidump_ok));
         #[cfg(target_os = "linux")]
-        diagnostics.register(ThreadDumpDiagnostic);
+        diagnostics.register(ThreadDumpDiagnostic::new(socket_dir));
     }
 
     metrics::init(&metrics);

--- a/witchcraft-server/src/lib.rs
+++ b/witchcraft-server/src/lib.rs
@@ -48,9 +48,9 @@
 //! Witchcraft divides configuration into two categories:
 //!
 //! * *Install* - Configuration that is fixed for the lifetime of a service. For example, the port that the server
-//!     listens on is part of the server's install configuration.
+//!   listens on is part of the server's install configuration.
 //! * *Runtime* - Configuration that can dynamically update while the service is running. For example, the logging
-//!     verbosity level is part of the server's runtime configuration.
+//!   verbosity level is part of the server's runtime configuration.
 //!
 //! Configuration is loaded from the `var/conf/install.yml` and `var/conf/runtime.yml` files respectively. The
 //! `runtime.yml` file is automatically checked for updates every few seconds.
@@ -95,7 +95,7 @@
 //! The server's configuration deserializer supports two methods to handle sensitive values:
 //!
 //! * `${enc:5BBfGvf90H6bApwfx...}` - inline in an encrypted form using [`serde_encrypted_value`] with the
-//!     key stored in `var/conf/encrypted-config-value.key`.
+//!   key stored in `var/conf/encrypted-config-value.key`.
 //! * `${file:/mnt/secrets/foo}` - as a reference to a file containing the value using [`serde_file_value`].
 //!
 //! ## Refreshable runtime configuration
@@ -156,9 +156,9 @@
 //!
 //! * `CONFIG_RELOAD` - Reports an error state if the runtime configuration failed to reload properly.
 //! * `ENDPOINT_FIVE_HUNDREDS` - Reports a warning if an endpoint has a high rate of `500 Internal Server Error`
-//!     responses.
+//!   responses.
 //! * `SERVICE_DEPENDENCY` - Tracks the status of requests made with HTTP clients created via the server's client
-//!     factory, and reports a warning state of requests to a remote service have a high failure rate.
+//!   factory, and reports a warning state of requests to a remote service have a high failure rate.
 //! * `PANICS` - Reports a warning if the server has panicked at any point.
 //!
 //! # Diagnostics
@@ -170,12 +170,12 @@
 //!
 //! * `diagnostic.types.v1` - Returns a JSON-encoded list of all valid diagnostic types.
 //! * `rust.heap.status.v1` - Returns detailed statistics about the state of the heap. Requires the `jemalloc` feature
-//!     (enabled by default).
+//!   (enabled by default).
 //! * `rust.heap.profile.v1` - Returns a profile of the source of a sample of live allocations. Use the `jeprof` tool
-//!     to analyze the profile. Requires the `jemalloc` feature (enabled by default).
+//!   to analyze the profile. Requires the `jemalloc` feature (enabled by default).
 //! * `metric.names.v1` - Returns a JSON-encoded list of the names of all metrics registered with the server.
 //! * `rust.thread.dump.v1` - Returns a stack trace of every thread in the process. Only supported when running on
-//!     Linux.
+//!   Linux.
 //!
 //! # Logging
 //!
@@ -221,10 +221,10 @@
 //! ## Thread Pool
 //!
 //! * `server.worker.max` (gauge) - The configured maximum size of the server's thread pool used for requests to
-//!     blocking endpoints.
+//!   blocking endpoints.
 //! * `server.worker.active` (gauge) - The number of threads actively processing requests to blocking endpoints.
 //! * `server.worker.utilization-max` (gauge) - `server.worker.active` divided by `server.worker.max`. If this is 1, the
-//!     server will immediately reject calls to blocking endpoints with a `503 Service Unavailable` status code.
+//!   server will immediately reject calls to blocking endpoints with a `503 Service Unavailable` status code.
 //!
 //! ## Logging
 //!
@@ -233,34 +233,34 @@
 //! ## Process
 //!
 //! * `process.heap` (gauge) - The total number of bytes allocated from the heap. Requires the `jemalloc` feature
-//!     (enabled by default).
+//!   (enabled by default).
 //! * `process.heap.active` (gauge) - The total number of bytes in active pages. Requires the `jemalloc` feature
-//!     (enabled by default).
+//!   (enabled by default).
 //! * `process.heap.resident` (gauge) - The total number of bytes in physically resident pages. Requires the `jemalloc` feature
-//!     (enabled by default).
+//!   (enabled by default).
 //! * `process.uptime` (gauge) - The number of microseconds that have elapsed since the server started.
 //! * `process.panics` (counter) - The number of times the server has panicked.
 //! * `process.user-time` (gauge) - The number of microseconds the process has spent running in user-space.
 //! * `process.user-time.norm` (gauge) - `process.user-time` divided by the number of CPU cores.
 //! * `process.system-time` (gauge) - The number of microseconds the process has spent either running in kernel-space
-//!     or in uninterruptable IO wait.
+//!   or in uninterruptable IO wait.
 //! * `process.system-time.norm` (gauge) - `process.system-time` divided by the number of CPU cores.
 //! * `process.blocks-read` (gauge) - The number of filesystem blocks the server has read.
 //! * `process.blocks-written` (gauge) - The number of filesystem blocks the server has written.
 //! * `process.threads` (gauge) - The number of threads in the process.
 //! * `process.filedescriptor` (gauge) - The number of file descriptors held open by the process divided by the maximum
-//!     number of files the server may hold open.
+//!   number of files the server may hold open.
 //!
 //! ## Connection
 //!
 //! * `server.connection.active` (counter) - The number of TCP sockets currently connected to the HTTP server.
 //! * `server.connection.utilization` (gauge) - `server.connection.active` divided by the maximum number of connections
-//!     the server will accept.
+//!   the server will accept.
 //!
 //! ## TLS
 //!
 //! * `tls.handshake (context: server, protocol: <protocol>, cipher: <cipher>)` (meter) - The rate of TLS handshakes
-//!     completed by the HTTP server.
+//!   completed by the HTTP server.
 //!
 //! ## Server
 //!
@@ -277,9 +277,9 @@
 //! ## Endpoints
 //!
 //! * `server.response (service-name: <service_name>, endpoint: <endpoint>)` (timer) - The amount of time required to
-//!     process each request to the endpoint, including sending the entire response body.
+//!   process each request to the endpoint, including sending the entire response body.
 //! * `server.response.error (service-name: <service_name>, endpoint: <endpoint>)` (meter) - The rate of `5xx` errors
-//!     returned for requests to the endpoint.
+//!   returned for requests to the endpoint.
 //!
 //! ## HTTP clients
 //!

--- a/witchcraft-server/src/lib.rs
+++ b/witchcraft-server/src/lib.rs
@@ -287,6 +287,7 @@
 #![warn(missing_docs)]
 
 use std::env;
+use std::path::Path;
 use std::pin::pin;
 use std::process;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
@@ -415,8 +416,9 @@ where
 {
     logging::early_init();
 
-    if env::args_os().nth(1).is_some_and(|a| a == "minidump") {
-        return minidump::server();
+    let args = env::args_os().collect::<Vec<_>>();
+    if args.len() == 3 && args[1] == "minidump" {
+        return minidump::server(Path::new(&args[2]));
     }
 
     let install_config = load_install()?;

--- a/witchcraft-server/src/minidump/log.rs
+++ b/witchcraft-server/src/minidump/log.rs
@@ -78,6 +78,13 @@ fn format_dump(state: &ProcessState) -> String {
         format_thread(&mut buf, thread);
     }
 
+    if let Some(soft_errors) = &state.soft_errors {
+        let soft_errors = serde_json::to_string_pretty(soft_errors).unwrap();
+        writeln!(buf).unwrap();
+        writeln!(buf, "Soft errors:").unwrap();
+        writeln!(buf, "{soft_errors}").unwrap();
+    }
+
     buf
 }
 

--- a/witchcraft-server/src/minidump/mod.rs
+++ b/witchcraft-server/src/minidump/mod.rs
@@ -30,7 +30,7 @@ pub mod log;
 
 const SOCKET_ADDR: &str = "var/data/tmp/minidump.sock";
 
-pub async fn init() -> Result<(), Error> {
+pub async fn init(_socket_dir: &Path) -> Result<(), Error> {
     log_dumps().await?;
 
     fs::create_dir_all(Path::new(SOCKET_ADDR).parent().unwrap()).map_err(Error::internal_safe)?;
@@ -42,7 +42,7 @@ pub async fn init() -> Result<(), Error> {
         .spawn()
         .map_err(Error::internal_safe)?;
 
-    let client = connect().await?;
+    let client = connect(_socket_dir).await?;
 
     // Enable the child to trace us in restricted ptrace linux environments
     #[cfg(target_os = "linux")]
@@ -96,7 +96,7 @@ fn handle_restricted_ptrace(child: u32) -> Result<(), Error> {
     Ok(())
 }
 
-pub async fn connect() -> Result<minidumper::Client, Error> {
+pub async fn connect(_socket_dir: &Path) -> Result<minidumper::Client, Error> {
     for _ in 0..200 {
         match tokio::task::spawn_blocking(|| minidumper::Client::with_name(Path::new(SOCKET_ADDR)))
             .await

--- a/witchcraft-server/src/minidump/mod.rs
+++ b/witchcraft-server/src/minidump/mod.rs
@@ -28,21 +28,24 @@ use witchcraft_log::{debug, error};
 
 pub mod log;
 
-const SOCKET_ADDR: &str = "var/data/tmp/minidump.sock";
+const SOCKET_FILE: &str = "minidump.sock";
 
-pub async fn init(_socket_dir: &Path) -> Result<(), Error> {
+pub async fn init(socket_dir: &Path) -> Result<(), Error> {
     log_dumps().await?;
 
-    fs::create_dir_all(Path::new(SOCKET_ADDR).parent().unwrap()).map_err(Error::internal_safe)?;
+    fs::create_dir_all(socket_dir).map_err(Error::internal_safe)?;
+
+    let socket_addr = socket_dir.join(SOCKET_FILE);
 
     let exe = env::current_exe().map_err(Error::internal_safe)?;
     let child = Command::new(exe)
         .arg("minidump")
+        .arg(&socket_addr)
         .stdin(Stdio::piped())
         .spawn()
         .map_err(Error::internal_safe)?;
 
-    let client = connect(_socket_dir).await?;
+    let client = connect(socket_dir).await?;
 
     // Enable the child to trace us in restricted ptrace linux environments
     #[cfg(target_os = "linux")]
@@ -96,12 +99,18 @@ fn handle_restricted_ptrace(child: u32) -> Result<(), Error> {
     Ok(())
 }
 
-pub async fn connect(_socket_dir: &Path) -> Result<minidumper::Client, Error> {
+pub async fn connect(socket_dir: &Path) -> Result<minidumper::Client, Error> {
+    let socket_addr = socket_dir.join(SOCKET_FILE);
+
     for _ in 0..200 {
-        match tokio::task::spawn_blocking(|| minidumper::Client::with_name(Path::new(SOCKET_ADDR)))
-            .await
-            .unwrap()
-        {
+        let result = tokio::task::spawn_blocking({
+            let socket_addr = socket_addr.clone();
+            move || minidumper::Client::with_name(&*socket_addr)
+        })
+        .await
+        .unwrap();
+
+        match result {
             Ok(client) => return Ok(client),
             Err(e) => debug!(
                 "error opening minidump client",
@@ -115,7 +124,7 @@ pub async fn connect(_socket_dir: &Path) -> Result<minidumper::Client, Error> {
     Err(Error::internal_safe("unable to connect to minidump server"))
 }
 
-pub fn server() -> Result<(), Error> {
+pub fn server(socket_addr: &Path) -> Result<(), Error> {
     let shutdown = Arc::new(AtomicBool::new(false));
 
     thread::spawn({
@@ -126,7 +135,7 @@ pub fn server() -> Result<(), Error> {
         }
     });
 
-    minidumper::Server::with_name(Path::new(SOCKET_ADDR))
+    minidumper::Server::with_name(socket_addr)
         .map_err(Error::internal_safe)?
         .run(Box::new(WitchcraftServerHandler), &shutdown, None)
         .map_err(Error::internal_safe)


### PR DESCRIPTION
## Before this PR
The Unix socket used to communicate with the minidump sidecar was always created in `var/data/tmp`. While this is the "proper" place to put it in the SLS layout, it can cause issues in some scenarios, like when volume mounting `var/data` in Docker. There was also no way to disable the minidumper entirely in contexts where it wasn't desired.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Added configuration options to disable the minidumper and configure its socket dir.
==COMMIT_MSG==