### PR TITLE
Don't start the management server early

### DIFF
--- a/witchcraft-server/src/lib.rs
+++ b/witchcraft-server/src/lib.rs
@@ -286,13 +286,13 @@
 //! See the documentation of the [`conjure_runtime`] crate for the metrics reported by HTTP clients.
 #![warn(missing_docs)]
 
-use std::env;
 use std::path::Path;
 use std::pin::pin;
 use std::process;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
+use std::{env, mem};
 
 use conjure_error::Error;
 use conjure_http::server::{AsyncService, ConjureRuntime};
@@ -530,18 +530,9 @@ where
         DebugServiceEndpoints::new(DebugResource::new(&runtime_config, &diagnostics));
     witchcraft.app(debug_endpoints);
 
-    // server::start clears out the previously-registered endpoints so the existing Witchcraft
-    // is ready to reuse for the main port afterwards.
-    if let Some(management_port) = install_config.as_ref().management_port() {
-        if management_port != install_config.as_ref().port() {
-            handle.block_on(server::start(
-                &mut witchcraft,
-                &loggers,
-                Listener::Management,
-                management_port,
-            ))?;
-        }
-    }
+    // A bit of a dance to avoid activating the management server before init returns, which would
+    // cause us to report ready too early.
+    let management_endpoints = mem::take(&mut witchcraft.endpoints);
 
     init(install_config, runtime_config, &mut witchcraft)?;
 
@@ -549,9 +540,25 @@ where
         .health_checks
         .register(Endpoint500sHealthCheck::new(&witchcraft.endpoints));
 
+    let mut main_endpoints = mem::take(&mut witchcraft.endpoints);
+
+    match witchcraft.install_config.management_port() {
+        Some(management_port) if management_port != witchcraft.install_config.port() => {
+            handle.block_on(server::start(
+                &mut witchcraft,
+                management_endpoints,
+                &loggers,
+                Listener::Management,
+                management_port,
+            ))?;
+        }
+        _ => main_endpoints.extend(management_endpoints),
+    }
+
     let port = witchcraft.install_config.port();
     handle.block_on(server::start(
         &mut witchcraft,
+        main_endpoints,
         &loggers,
         Listener::Service,
         port,

--- a/witchcraft-server/src/server.rs
+++ b/witchcraft-server/src/server.rs
@@ -1,4 +1,3 @@
-use crate::endpoint::WitchcraftEndpoint;
 // Copyright 2022 Palantir Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@ use crate::endpoint::WitchcraftEndpoint;
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+use crate::endpoint::WitchcraftEndpoint;
 use crate::logging::Loggers;
 use crate::service::accept::AcceptService;
 use crate::service::audit_log::AuditLogLayer;

--- a/witchcraft-server/src/server.rs
+++ b/witchcraft-server/src/server.rs
@@ -1,3 +1,4 @@
+use crate::endpoint::WitchcraftEndpoint;
 // Copyright 2022 Palantir Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -50,7 +51,6 @@ use crate::service::{Service, ServiceBuilder};
 use crate::Witchcraft;
 use conjure_error::Error;
 use hyper::body::Incoming;
-use std::mem;
 use std::sync::Arc;
 use tokio::task;
 use witchcraft_log::debug;
@@ -74,13 +74,14 @@ impl Listener {
 
 pub(crate) async fn start(
     witchcraft: &mut Witchcraft,
+    endpoints: Vec<Box<dyn WitchcraftEndpoint + Sync + Send>>,
     loggers: &Loggers,
     listener: Listener,
     port: u16,
 ) -> Result<(), Error> {
     // This service handles individual HTTP requests, each running concurrently.
     let request_service = ServiceBuilder::new()
-        .layer(RoutingLayer::new(mem::take(&mut witchcraft.endpoints)))
+        .layer(RoutingLayer::new(endpoints))
         .layer(RequestIdLayer)
         .layer(TracePropagationLayer)
         .layer(SpansLayer)


### PR DESCRIPTION
## Before this PR
If a server had the management port enabled, that server would be bound before the init function. In particular, this would mean the server would report ready early, potentially causing it to receive traffic before it was fully ready to serve it.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Deferred creation of the management server until after the init function returned.
==COMMIT_MSG==

This aligns the behavior of the with-management-port and without-management-port cases.

## Possible downsides?
There is a notable behavioral change for servers that enable the management port: the server will not report liveness until the init function returns. If a server has a long-running init function, this may cause orchestration runtimes like Kubernetes to assume the server is nonfunctional and kill it.

We could alternatively continue binding the management server early, but add a readiness check on the init function returning. I think this approach is a bit cleaner though, since it ensures that the server is fully initialized before we start serving anything.