### PR TITLE
Make management-port required

### DIFF
--- a/witchcraft-server-config/src/install/de.rs
+++ b/witchcraft-server-config/src/install/de.rs
@@ -21,7 +21,7 @@ pub struct InstallConfig {
     pub product_name: String,
     pub product_version: String,
     pub port: u16,
-    pub management_port: Option<u16>,
+    pub management_port: u16,
     pub keystore: Option<super::KeystoreConfig>,
     pub client_auth_truststore: Option<super::ClientAuthTruststoreConfig>,
     pub context_path: Option<String>,

--- a/witchcraft-server-config/src/install/mod.rs
+++ b/witchcraft-server-config/src/install/mod.rs
@@ -32,8 +32,7 @@ pub struct InstallConfig {
     #[builder(into)]
     product_version: String,
     port: u16,
-    #[builder(default, into)]
-    management_port: Option<u16>,
+    management_port: u16,
     #[builder(default)]
     keystore: KeystoreConfig,
     #[builder(default, into)]
@@ -73,10 +72,8 @@ impl<'de> Deserialize<'de> for InstallConfig {
         let mut builder = InstallConfig::builder()
             .product_name(raw.product_name)
             .product_version(raw.product_version)
-            .port(raw.port);
-        if let Some(management_port) = raw.management_port {
-            builder = builder.management_port(management_port);
-        }
+            .port(raw.port)
+            .management_port(raw.management_port);
         if let Some(keystore) = raw.keystore {
             builder = builder.keystore(keystore);
         }
@@ -133,8 +130,9 @@ impl InstallConfig {
 
     /// Returns the port that the server's management APIs will listen on.
     ///
-    /// Defaults to `port()`.
-    pub fn management_port(&self) -> Option<u16> {
+    /// Required.
+    #[inline]
+    pub fn management_port(&self) -> u16 {
         self.management_port
     }
 

--- a/witchcraft-server-ete/tests/ete/main.rs
+++ b/witchcraft-server-ete/tests/ete/main.rs
@@ -188,7 +188,7 @@ async fn health_check_bad_auth() {
             .body(Empty::<Bytes>::new())
             .unwrap();
         let response = server
-            .client()
+            .management_client()
             .await
             .unwrap()
             .send_request(request)
@@ -211,7 +211,7 @@ async fn health_check() {
             .body(Empty::<Bytes>::new())
             .unwrap();
         let response = server
-            .client()
+            .management_client()
             .await
             .unwrap()
             .send_request(request)
@@ -238,7 +238,7 @@ async fn diagnostic_types_bad_auth() {
             .body(Empty::<Bytes>::new())
             .unwrap();
         let response = server
-            .client()
+            .management_client()
             .await
             .unwrap()
             .send_request(request)
@@ -261,7 +261,7 @@ async fn diagnostic_types_diagnostic() {
             .body(Empty::<Bytes>::new())
             .unwrap();
         let response = server
-            .client()
+            .management_client()
             .await
             .unwrap()
             .send_request(request)
@@ -294,7 +294,7 @@ async fn thread_dump_diagnostic() {
             .body(Empty::<Bytes>::new())
             .unwrap();
         let response = server
-            .client()
+            .management_client()
             .await
             .unwrap()
             .send_request(request)

--- a/witchcraft-server-ete/tests/ete/server/mod.rs
+++ b/witchcraft-server-ete/tests/ete/server/mod.rs
@@ -100,7 +100,7 @@ impl Drop for Server {
 impl Server {
     pub fn builder() -> Builder {
         Builder {
-            management_port: None,
+            management_port: Some(open_port()),
             http2: false,
         }
     }

--- a/witchcraft-server/src/lib.rs
+++ b/witchcraft-server/src/lib.rs
@@ -87,6 +87,7 @@
 //! product-name: my-service
 //! product-version: 1.0.0
 //! port: 12345
+//! management-port: 12346
 //! shave-yaks: true
 //! ```
 //!
@@ -540,20 +541,16 @@ where
         .health_checks
         .register(Endpoint500sHealthCheck::new(&witchcraft.endpoints));
 
-    let mut main_endpoints = mem::take(&mut witchcraft.endpoints);
+    let main_endpoints = mem::take(&mut witchcraft.endpoints);
 
-    match witchcraft.install_config.management_port() {
-        Some(management_port) if management_port != witchcraft.install_config.port() => {
-            handle.block_on(server::start(
-                &mut witchcraft,
-                management_endpoints,
-                &loggers,
-                Listener::Management,
-                management_port,
-            ))?;
-        }
-        _ => main_endpoints.extend(management_endpoints),
-    }
+    let management_port = witchcraft.install_config.management_port();
+    handle.block_on(server::start(
+        &mut witchcraft,
+        management_endpoints,
+        &loggers,
+        Listener::Management,
+        management_port,
+    ))?;
 
     let port = witchcraft.install_config.port();
     handle.block_on(server::start(


### PR DESCRIPTION
## Before this PR

`management-port` was optional. If left out, status endpoints got served on the main port. That fallback existed for the migration to a dedicated management port, which is done. See #281.

## After this PR
==COMMIT_MSG==
`management-port` is required in install config.
==COMMIT_MSG==

## Possible downsides?

Breaking config change. Any service still omitting `management-port` will fail to start until it's added. Also updated the example in the crate docs so it doesn't show a stale config without the field.