### PR TITLE
Fix public-type-in-private build error

### DIFF
--- a/witchcraft-server/src/status.rs
+++ b/witchcraft-server/src/status.rs
@@ -29,7 +29,7 @@ use tokio::task;
 use witchcraft_server_config::runtime::RuntimeConfig;
 
 #[conjure_endpoints]
-pub trait StatusService {
+pub(crate) trait StatusService {
     #[endpoint(path = "/status/liveness", method = GET)]
     async fn liveness(&self) -> Result<(), Error>;
 
@@ -40,7 +40,7 @@ pub trait StatusService {
     async fn health(&self, #[auth] token: BearerToken) -> Result<HealthStatus, Error>;
 }
 
-pub struct StatusResource {
+pub(crate) struct StatusResource {
     health_check_secret: Refreshable<String, Error>,
     health_checks: Arc<HealthCheckRegistry>,
     readiness_checks: Arc<ReadinessCheckRegistry>,


### PR DESCRIPTION
Looks like Rust 1.96.0 got a bit more picky here:

```
error[E0446]: crate-private type `ReadinessCheckMetadata` in public interface
   --> witchcraft-server/src/status.rs:31:1
    |
 31 | #[conjure_endpoints]
    | ^^^^^^^^^^^^^^^^^^^^ can't leak crate-private type
    |
   ::: witchcraft-server/src/readiness.rs:121:1
    |
121 | pub(crate) struct ReadinessCheckMetadata {
    | ---------------------------------------- `ReadinessCheckMetadata` declared as crate-private

error[E0446]: crate-private type `ReadinessCheckMetadata` in public interface
   --> witchcraft-server/src/status.rs:72:34
    |
 72 |     async fn readiness(&self) -> Result<BTreeMap<String, ReadinessCheckMetadata>, Error> {
    |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak crate-private type
    |
   ::: witchcraft-server/src/readiness.rs:121:1
    |
121 | pub(crate) struct ReadinessCheckMetadata {
    | ---------------------------------------- `ReadinessCheckMetadata` declared as crate-private
```