### PR TITLE
Allow in-memory init of multiple servers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@
 version: 2.1
 jobs:
   build:
-    docker: [{ image: cimg/rust:1.88.0 }]
+    docker: [{ image: cimg/rust:1.89.0 }]
     environment:
       CARGO_BUILD_RUSTFLAGS: -Dwarnings
       RUST_BACKTRACE: 1
@@ -19,12 +19,12 @@ jobs:
           paths:
             - /home/circleci/.cargo/registry/index
       - restore_cache:
-          key: deps-1.88.0-{{ checksum "Cargo.lock" }}
+          key: deps-1.89.0-{{ checksum "Cargo.lock" }}
       - run: cargo fmt --all -- --check
       - run: cargo clippy --all --all-targets
       - run: cargo test --all
       - save_cache:
-          key: deps-1.88.0-{{ checksum "Cargo.lock" }}
+          key: deps-1.89.0-{{ checksum "Cargo.lock" }}
           paths:
             - target
             - /home/circleci/.cargo/registry/cache

--- a/.circleci/template.sh
+++ b/.circleci/template.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 export CIRCLECI_TEMPLATE=rust-library-oss
-export RUST_VERSION=1.88.0
+export RUST_VERSION=1.89.0

--- a/witchcraft-server/Cargo.toml
+++ b/witchcraft-server/Cargo.toml
@@ -30,6 +30,7 @@ docs = "A recording of running threads and their respective stacktraces."
 [features]
 default = ["jemalloc"]
 jemalloc = ["dep:tikv-jemalloc-ctl", "dep:tikv-jemallocator"]
+in-memory-testing = []
 
 [dependencies]
 arc-swap = "1"

--- a/witchcraft-server/src/blocking/pool/mod.rs
+++ b/witchcraft-server/src/blocking/pool/mod.rs
@@ -97,10 +97,11 @@ impl Shared {
 
 pub struct ThreadPool {
     shared: Arc<Shared>,
+    thread_prefix: String,
 }
 
 impl ThreadPool {
-    pub fn new(config: &InstallConfig, metrics: &MetricRegistry) -> Self {
+    pub fn new(config: &InstallConfig, metrics: &MetricRegistry, thread_prefix: String) -> Self {
         let pool = ThreadPool {
             shared: Arc::new(Shared {
                 min_threads: config.server().min_threads(),
@@ -113,6 +114,7 @@ impl ThreadPool {
                     next_id: 0,
                 }),
             }),
+            thread_prefix,
         };
 
         metrics.gauge("server.worker.max", {
@@ -144,10 +146,12 @@ impl ThreadPool {
 
         let id = state.next_id;
         state.next_id += 1;
-        let r = thread::Builder::new().name(format!("server-{id}")).spawn({
-            let shared = self.shared.clone();
-            move || shared.worker_loop()
-        });
+        let r = thread::Builder::new()
+            .name(format!("{}server-{id}", self.thread_prefix))
+            .spawn({
+                let shared = self.shared.clone();
+                move || shared.worker_loop()
+            });
 
         match r {
             Ok(_) => state.threads += 1,

--- a/witchcraft-server/src/blocking/pool/mod.rs
+++ b/witchcraft-server/src/blocking/pool/mod.rs
@@ -97,11 +97,15 @@ impl Shared {
 
 pub struct ThreadPool {
     shared: Arc<Shared>,
-    thread_prefix: String,
+    thread_prefix: Option<String>,
 }
 
 impl ThreadPool {
-    pub fn new(config: &InstallConfig, metrics: &MetricRegistry, thread_prefix: String) -> Self {
+    pub fn new(
+        config: &InstallConfig,
+        metrics: &MetricRegistry,
+        thread_prefix: Option<String>,
+    ) -> Self {
         let pool = ThreadPool {
             shared: Arc::new(Shared {
                 min_threads: config.server().min_threads(),
@@ -146,8 +150,13 @@ impl ThreadPool {
 
         let id = state.next_id;
         state.next_id += 1;
+        let thread_prefix = self
+            .thread_prefix
+            .as_ref()
+            .map(|tp| tp.as_str())
+            .unwrap_or("server");
         let r = thread::Builder::new()
-            .name(format!("{}server-{id}", self.thread_prefix))
+            .name(format!("{}-{id}", thread_prefix))
             .spawn({
                 let shared = self.shared.clone();
                 move || shared.worker_loop()

--- a/witchcraft-server/src/blocking/pool/mod.rs
+++ b/witchcraft-server/src/blocking/pool/mod.rs
@@ -150,9 +150,7 @@ impl ThreadPool {
 
         let id = state.next_id;
         state.next_id += 1;
-        let thread_prefix = self
-            .thread_prefix.as_deref()
-            .unwrap_or("server");
+        let thread_prefix = self.thread_prefix.as_deref().unwrap_or("server");
         let r = thread::Builder::new()
             .name(format!("{}-{id}", thread_prefix))
             .spawn({

--- a/witchcraft-server/src/blocking/pool/mod.rs
+++ b/witchcraft-server/src/blocking/pool/mod.rs
@@ -151,9 +151,7 @@ impl ThreadPool {
         let id = state.next_id;
         state.next_id += 1;
         let thread_prefix = self
-            .thread_prefix
-            .as_ref()
-            .map(|tp| tp.as_str())
+            .thread_prefix.as_deref()
             .unwrap_or("server");
         let r = thread::Builder::new()
             .name(format!("{}-{id}", thread_prefix))

--- a/witchcraft-server/src/lib.rs
+++ b/witchcraft-server/src/lib.rs
@@ -389,7 +389,13 @@ where
 {
     let mut runtime_guard = None;
 
-    let ret = match init_inner(init, load_install, load_runtime, &mut runtime_guard) {
+    let ret = match init_inner(
+        init,
+        load_install,
+        load_runtime,
+        &mut runtime_guard,
+        InitOptions::default(),
+    ) {
         Ok(()) => 0,
         Err(e) => {
             fatal!("error starting server", error: e);
@@ -401,11 +407,67 @@ where
     process::exit(ret);
 }
 
+#[cfg(feature = "in-memory-testing")]
+/// Initializes a Witchcraft server for testing with custom config loaders. This variation of init
+/// can initialize a Witchcraft server that's running in a thread, rather than as a separate
+/// process. Note: only one in-memory server can initialize logging (`init_log = true`). Use the
+/// `thread_prefix` parameter to differentiate log messages across servers.
+pub fn init_with_configs_for_tests<I, R, F, LI, LR>(
+    init: F,
+    load_install: LI,
+    load_runtime: LR,
+    init_log: bool,
+    thread_prefix: Option<String>,
+) where
+    I: AsRef<InstallConfig> + DeserializeOwned,
+    R: AsRef<RuntimeConfig> + DeserializeOwned + PartialEq + 'static + Sync + Send,
+    F: FnOnce(I, Refreshable<R, Error>, &mut Witchcraft) -> Result<(), Error>,
+    LI: FnOnce() -> Result<I, Error>,
+    LR: FnOnce(&Handle, &Arc<AtomicBool>) -> Result<Refreshable<R, Error>, Error>,
+{
+    let mut runtime_guard = None;
+
+    let ret = match init_inner(
+        init,
+        load_install,
+        load_runtime,
+        &mut runtime_guard,
+        InitOptions {
+            init_log,
+            thread_prefix: thread_prefix.unwrap_or_else(|| "".into()),
+        },
+    ) {
+        Ok(()) => 0,
+        Err(e) => {
+            fatal!("error starting server", error: e);
+            1
+        }
+    };
+    drop(runtime_guard);
+
+    process::exit(ret);
+}
+
+struct InitOptions {
+    init_log: bool,
+    thread_prefix: String,
+}
+
+impl Default for InitOptions {
+    fn default() -> Self {
+        Self {
+            init_log: true,
+            thread_prefix: "".to_string(),
+        }
+    }
+}
+
 fn init_inner<I, R, F, LI, LR>(
     init: F,
     load_install: LI,
     load_runtime: LR,
     runtime_guard: &mut Option<RuntimeGuard>,
+    init_options: InitOptions,
 ) -> Result<(), Error>
 where
     I: AsRef<InstallConfig> + DeserializeOwned,
@@ -414,7 +476,9 @@ where
     LI: FnOnce() -> Result<I, Error>,
     LR: FnOnce(&Handle, &Arc<AtomicBool>) -> Result<Refreshable<R, Error>, Error>,
 {
-    logging::early_init();
+    if init_options.init_log {
+        logging::early_init();
+    }
 
     let args = env::args_os().collect::<Vec<_>>();
     if args.len() == 3 && args[1] == "minidump" {
@@ -424,9 +488,16 @@ where
     let install_config = load_install()?;
 
     let thread_id = AtomicUsize::new(0);
+    let thread_prefix = init_options.thread_prefix.clone();
     let runtime = runtime::Builder::new_multi_thread()
         .enable_all()
-        .thread_name_fn(move || format!("runtime-{}", thread_id.fetch_add(1, Ordering::Relaxed)))
+        .thread_name_fn(move || {
+            format!(
+                "{}runtime-{}",
+                thread_prefix,
+                thread_id.fetch_add(1, Ordering::Relaxed)
+            )
+        })
         .worker_threads(install_config.as_ref().server().io_threads())
         .thread_keep_alive(install_config.as_ref().server().idle_thread_timeout())
         .build()
@@ -447,12 +518,16 @@ where
     let readiness_checks = Arc::new(ReadinessCheckRegistry::new());
     let diagnostics = Arc::new(DiagnosticRegistry::new());
 
-    let loggers = handle.block_on(logging::init(
-        &metrics,
-        install_config.as_ref(),
-        &runtime_config.map(|c| c.as_ref().logging().clone()),
-        runtime.logger_shutdown.as_mut().unwrap(),
-    ))?;
+    let loggers = if init_options.init_log {
+        handle.block_on(logging::init(
+            &metrics,
+            install_config.as_ref(),
+            &runtime_config.map(|c| c.as_ref().logging().clone()),
+            runtime.logger_shutdown.as_mut().unwrap(),
+        ))
+    } else {
+        logging::get_existing()
+    }?;
 
     info!("server starting");
 
@@ -510,6 +585,7 @@ where
         handle: handle.clone(),
         install_config: install_config.as_ref().clone(),
         thread_pool: None,
+        thread_prefix: init_options.thread_prefix,
         endpoints: vec![],
         shutdown_hooks: ShutdownHooks::new(),
         conjure_runtime: Arc::new(ConjureRuntime::new()),

--- a/witchcraft-server/src/lib.rs
+++ b/witchcraft-server/src/lib.rs
@@ -387,70 +387,163 @@ where
     LI: FnOnce() -> Result<I, Error>,
     LR: FnOnce(&Handle, &Arc<AtomicBool>) -> Result<Refreshable<R, Error>, Error>,
 {
-    let mut runtime_guard = None;
+    logging::early_init();
 
-    let ret = match init_inner(
-        init,
-        load_install,
-        load_runtime,
-        &mut runtime_guard,
-        InitOptions::default(),
-    ) {
-        Ok(()) => 0,
-        Err(e) => {
-            fatal!("error starting server", error: e);
-            1
-        }
-    };
-    drop(runtime_guard);
+    let args = env::args_os().collect::<Vec<_>>();
+    if args.len() == 3 && args[1] == "minidump" {
+        let ret = match minidump::server(Path::new(&args[2])) {
+            Ok(()) => 0,
+            Err(e) => {
+                fatal!("error starting minidump server", error: e);
+                1
+            }
+        };
+        process::exit(ret);
+    } else {
+        let mut runtime_guard = None;
 
-    process::exit(ret);
+        let ret = match init_inner(
+            init,
+            load_install,
+            load_runtime,
+            &mut runtime_guard,
+            InitOptions::default(),
+        ) {
+            Ok(witchcraft) => {
+                match witchcraft.handle.block_on(shutdown(
+                    witchcraft.shutdown_hooks,
+                    witchcraft.install_config.server().shutdown_timeout(),
+                )) {
+                    Ok(_) => 0,
+                    Err(e) => {
+                        fatal!("error after starting server", error: e);
+                        1
+                    }
+                }
+            }
+            Err(e) => {
+                fatal!("error starting server", error: e);
+                1
+            }
+        };
+        drop(runtime_guard);
+
+        process::exit(ret);
+    }
 }
 
 #[cfg(feature = "in-memory-testing")]
-static GLOBALS_INITIALIZED: std::sync::OnceLock<AtomicBool> = std::sync::OnceLock::new();
+/// Variation of the Witchcraft server initialization, which can be used for testing. Allows
+/// spawning multiple instances of the server in memory.
+pub mod in_memory_testing {
+    use crate::{drain_shutdown_hooks, init_inner, logging, InitOptions, Witchcraft};
+    use conjure_error::Error;
+    use refreshable::Refreshable;
+    use serde::de::DeserializeOwned;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::{mpsc, Arc};
+    use std::thread::{self, JoinHandle};
+    use tokio::runtime::Handle;
+    use tokio::sync::oneshot;
+    use witchcraft_server_config::install::InstallConfig;
+    use witchcraft_server_config::runtime::RuntimeConfig;
 
-#[cfg(feature = "in-memory-testing")]
-/// Initializes a Witchcraft server for testing with custom config loaders. This variation of init
-/// can initialize a Witchcraft server that's running in a thread, rather than as a separate
-/// process. Note: only one in-memory server can initialize logging (`init_log = true`). Use the
-/// `thread_prefix` parameter to differentiate log messages across servers.
-pub fn init_with_configs_for_tests<I, R, F, LI, LR>(
-    init: F,
-    load_install: LI,
-    load_runtime: LR,
-    thread_prefix: Option<String>,
-) where
-    I: AsRef<InstallConfig> + DeserializeOwned,
-    R: AsRef<RuntimeConfig> + DeserializeOwned + PartialEq + 'static + Sync + Send,
-    F: FnOnce(I, Refreshable<R, Error>, &mut Witchcraft) -> Result<(), Error>,
-    LI: FnOnce() -> Result<I, Error>,
-    LR: FnOnce(&Handle, &Arc<AtomicBool>) -> Result<Refreshable<R, Error>, Error>,
-{
-    let globals_initialized = GLOBALS_INITIALIZED.get_or_init(|| AtomicBool::new(false));
-    let init_globals = !globals_initialized.swap(true, Ordering::Relaxed);
+    static GLOBALS_INITIALIZED: std::sync::OnceLock<AtomicBool> = std::sync::OnceLock::new();
 
-    let mut runtime_guard = None;
+    /// Initializes a Witchcraft server for testing with custom config loaders. This variation of init
+    /// can initialize a Witchcraft server that's running in a thread, rather than as a separate
+    /// process. Note: only one in-memory server can initialize logging (`init_log = true`). Use the
+    /// `thread_prefix` parameter to differentiate log messages across servers.
+    ///
+    /// The server runs on a dedicated thread, and the returned [`RunHandle`] shuts the
+    /// server down gracefully when dropped. Note that the first call to this init function will
+    /// also initialize global shared logging; and the returned handle will shut down the appenders
+    /// on drop. Ensure that first initialized server is the last one to go out of scope.
+    pub fn init_with_configs_for_tests<I, R, F, LI, LR>(
+        init: F,
+        load_install: LI,
+        load_runtime: LR,
+        thread_prefix: Option<String>,
+    ) -> Result<RunHandle, Error>
+    where
+        I: AsRef<InstallConfig> + DeserializeOwned,
+        R: AsRef<RuntimeConfig> + DeserializeOwned + PartialEq + 'static + Sync + Send,
+        F: FnOnce(I, Refreshable<R, Error>, &mut Witchcraft) -> Result<(), Error> + Send + 'static,
+        LI: FnOnce() -> Result<I, Error> + Send + 'static,
+        LR: FnOnce(&Handle, &Arc<AtomicBool>) -> Result<Refreshable<R, Error>, Error>
+            + Send
+            + 'static,
+    {
+        let globals_initialized = GLOBALS_INITIALIZED.get_or_init(|| AtomicBool::new(false));
+        let init_globals = !globals_initialized.swap(true, Ordering::Relaxed);
 
-    let ret = match init_inner(
-        init,
-        load_install,
-        load_runtime,
-        &mut runtime_guard,
-        InitOptions {
-            init_globals,
-            thread_prefix,
-        },
-    ) {
-        Ok(()) => 0,
-        Err(e) => {
-            fatal!("error starting server", error: e);
-            1
+        if init_globals {
+            logging::early_init();
         }
-    };
-    drop(runtime_guard);
 
-    process::exit(ret);
+        let (startup_result_sender, startup_result_receiver) = mpsc::channel::<Result<(), Error>>();
+        let (shutdown_signal_sender, shutdown_signal_receiver) = oneshot::channel::<()>();
+
+        // Dedicated thread for this server instance, allows it to create its own tokio runtime
+        let server_thread = thread::spawn(move || {
+            let mut runtime_guard = None;
+            let witchcraft = match init_inner(
+                init,
+                load_install,
+                load_runtime,
+                &mut runtime_guard,
+                InitOptions {
+                    init_globals,
+                    thread_prefix,
+                },
+            ) {
+                Ok(witchcraft) => witchcraft,
+                Err(e) => {
+                    let _ = startup_result_sender.send(Err(e));
+                    return;
+                }
+            };
+
+            let handle = witchcraft.handle.clone();
+            let timeout = witchcraft.install_config.server().shutdown_timeout();
+            let _ = startup_result_sender.send(Ok(()));
+
+            // Block the server until shutdown is called by the RunHandle's drop
+            handle.block_on(async move {
+                let _ = shutdown_signal_receiver.await;
+                    drain_shutdown_hooks(witchcraft.shutdown_hooks, timeout).await;
+            });
+            drop(runtime_guard);
+        });
+
+        // Wait for startup to finish before handing back a handle. A receive error means the thread
+        // panicked before reporting, dropping `startup_tx`.
+        match startup_result_receiver.recv() {
+            Ok(Ok(())) => Ok(RunHandle {
+                shutdown_signal_sender: Some(shutdown_signal_sender),
+                server_thread: Some(server_thread),
+            }),
+            Ok(Err(e)) => Err(e), // Error during init_error()
+            Err(_) => Err(Error::internal_safe(
+                "in-memory server thread panicked during initialization",
+            )),
+        }
+    }
+
+    /// Provides a handle for a running in-memory Witchcraft server. Gracefully shuts the server
+    /// down when it goes out of scope.
+    pub struct RunHandle {
+        shutdown_signal_sender: Option<oneshot::Sender<()>>,
+        server_thread: Option<JoinHandle<()>>,
+    }
+
+    impl Drop for RunHandle {
+        fn drop(&mut self) {
+            // Signal shutdown, then wait for the server thread to drain and tear down its runtime.
+            let _ = self.shutdown_signal_sender.take().unwrap().send(());
+            let _ = self.server_thread.take().unwrap().join();
+        }
+    }
 }
 
 struct InitOptions {
@@ -473,7 +566,7 @@ fn init_inner<I, R, F, LI, LR>(
     load_runtime: LR,
     runtime_guard: &mut Option<RuntimeGuard>,
     init_options: InitOptions,
-) -> Result<(), Error>
+) -> Result<Witchcraft, Error>
 where
     I: AsRef<InstallConfig> + DeserializeOwned,
     R: AsRef<RuntimeConfig> + DeserializeOwned + PartialEq + 'static + Sync + Send,
@@ -481,15 +574,6 @@ where
     LI: FnOnce() -> Result<I, Error>,
     LR: FnOnce(&Handle, &Arc<AtomicBool>) -> Result<Refreshable<R, Error>, Error>,
 {
-    if init_options.init_globals {
-        logging::early_init();
-    }
-
-    let args = env::args_os().collect::<Vec<_>>();
-    if args.len() == 3 && args[1] == "minidump" {
-        return minidump::server(Path::new(&args[2]));
-    }
-
     let install_config = load_install()?;
 
     let thread_id = AtomicUsize::new(0);
@@ -650,21 +734,28 @@ where
         port,
     ))?;
 
-    handle.block_on(shutdown(
-        witchcraft.shutdown_hooks,
-        witchcraft.install_config.server().shutdown_timeout(),
-    ))
+    Ok(witchcraft)
 }
 
 async fn shutdown(shutdown_hooks: ShutdownHooks, timeout: Duration) -> Result<(), Error> {
     let mut signals = pin!(signals()?);
 
     signals.next().await;
+
+    select! {
+        _ = drain_shutdown_hooks(shutdown_hooks, timeout) => {}
+        _ = signals.next() => info!("graceful shutdown interrupted by signal"),
+    }
+
+    Ok(())
+}
+
+/// Awaits the server's shutdown hooks, giving up after `timeout` elapses.
+async fn drain_shutdown_hooks(shutdown_hooks: ShutdownHooks, timeout: Duration) {
     info!("server shutting down");
 
     select! {
         _ = shutdown_hooks => {}
-        _ = signals.next() => info!("graceful shutdown interrupted by signal"),
         _ = time::sleep(timeout) => {
             info!(
                 "graceful shutdown timed out",
@@ -674,8 +765,6 @@ async fn shutdown(shutdown_hooks: ShutdownHooks, timeout: Duration) -> Result<()
             );
         }
     }
-
-    Ok(())
 }
 
 fn signals() -> Result<impl Stream<Item = ()>, Error> {

--- a/witchcraft-server/src/lib.rs
+++ b/witchcraft-server/src/lib.rs
@@ -434,7 +434,7 @@ pub fn init_with_configs_for_tests<I, R, F, LI, LR>(
         &mut runtime_guard,
         InitOptions {
             init_log,
-            thread_prefix: thread_prefix.unwrap_or_else(|| "".into()),
+            thread_prefix: thread_prefix.unwrap_or_else(|| NO_THREAD_PREFIX.to_string()),
         },
     ) {
         Ok(()) => 0,
@@ -448,6 +448,8 @@ pub fn init_with_configs_for_tests<I, R, F, LI, LR>(
     process::exit(ret);
 }
 
+const NO_THREAD_PREFIX: &str = "";
+
 struct InitOptions {
     init_log: bool,
     thread_prefix: String,
@@ -457,7 +459,7 @@ impl Default for InitOptions {
     fn default() -> Self {
         Self {
             init_log: true,
-            thread_prefix: "".to_string(),
+            thread_prefix: NO_THREAD_PREFIX.to_string(),
         }
     }
 }

--- a/witchcraft-server/src/lib.rs
+++ b/witchcraft-server/src/lib.rs
@@ -408,6 +408,9 @@ where
 }
 
 #[cfg(feature = "in-memory-testing")]
+static GLOBALS_INITIALIZED: std::sync::OnceLock<AtomicBool> = std::sync::OnceLock::new();
+
+#[cfg(feature = "in-memory-testing")]
 /// Initializes a Witchcraft server for testing with custom config loaders. This variation of init
 /// can initialize a Witchcraft server that's running in a thread, rather than as a separate
 /// process. Note: only one in-memory server can initialize logging (`init_log = true`). Use the
@@ -416,7 +419,6 @@ pub fn init_with_configs_for_tests<I, R, F, LI, LR>(
     init: F,
     load_install: LI,
     load_runtime: LR,
-    init_log: bool,
     thread_prefix: Option<String>,
 ) where
     I: AsRef<InstallConfig> + DeserializeOwned,
@@ -425,6 +427,9 @@ pub fn init_with_configs_for_tests<I, R, F, LI, LR>(
     LI: FnOnce() -> Result<I, Error>,
     LR: FnOnce(&Handle, &Arc<AtomicBool>) -> Result<Refreshable<R, Error>, Error>,
 {
+    let globals_initialized = GLOBALS_INITIALIZED.get_or_init(|| AtomicBool::new(false));
+    let init_globals = !globals_initialized.swap(true, Ordering::Relaxed);
+
     let mut runtime_guard = None;
 
     let ret = match init_inner(
@@ -433,8 +438,8 @@ pub fn init_with_configs_for_tests<I, R, F, LI, LR>(
         load_runtime,
         &mut runtime_guard,
         InitOptions {
-            init_log,
-            thread_prefix: thread_prefix.unwrap_or_else(|| NO_THREAD_PREFIX.to_string()),
+            init_globals,
+            thread_prefix,
         },
     ) {
         Ok(()) => 0,
@@ -448,18 +453,16 @@ pub fn init_with_configs_for_tests<I, R, F, LI, LR>(
     process::exit(ret);
 }
 
-const NO_THREAD_PREFIX: &str = "";
-
 struct InitOptions {
-    init_log: bool,
-    thread_prefix: String,
+    init_globals: bool,
+    thread_prefix: Option<String>,
 }
 
 impl Default for InitOptions {
     fn default() -> Self {
         Self {
-            init_log: true,
-            thread_prefix: NO_THREAD_PREFIX.to_string(),
+            init_globals: true,
+            thread_prefix: None,
         }
     }
 }
@@ -478,7 +481,7 @@ where
     LI: FnOnce() -> Result<I, Error>,
     LR: FnOnce(&Handle, &Arc<AtomicBool>) -> Result<Refreshable<R, Error>, Error>,
 {
-    if init_options.init_log {
+    if init_options.init_globals {
         logging::early_init();
     }
 
@@ -490,12 +493,15 @@ where
     let install_config = load_install()?;
 
     let thread_id = AtomicUsize::new(0);
-    let thread_prefix = init_options.thread_prefix.clone();
+    let thread_prefix = init_options
+        .thread_prefix
+        .clone()
+        .unwrap_or("runtime".to_string());
     let runtime = runtime::Builder::new_multi_thread()
         .enable_all()
         .thread_name_fn(move || {
             format!(
-                "{}runtime-{}",
+                "{}-{}",
                 thread_prefix,
                 thread_id.fetch_add(1, Ordering::Relaxed)
             )
@@ -520,7 +526,7 @@ where
     let readiness_checks = Arc::new(ReadinessCheckRegistry::new());
     let diagnostics = Arc::new(DiagnosticRegistry::new());
 
-    let loggers = if init_options.init_log {
+    let loggers = if init_options.init_globals {
         handle.block_on(logging::init(
             &metrics,
             install_config.as_ref(),
@@ -533,7 +539,7 @@ where
 
     info!("server starting");
 
-    if install_config.as_ref().minidump().enabled() {
+    if init_options.init_globals && install_config.as_ref().minidump().enabled() {
         let minidump_ok = Arc::new(AtomicBool::new(true));
         let socket_dir = install_config.as_ref().minidump().socket_dir();
         handle.spawn({
@@ -562,9 +568,11 @@ where
     diagnostics.register(MetricNamesDiagnostic::new(&metrics));
     #[cfg(feature = "jemalloc")]
     {
-        diagnostics.register(HeapStatsDiagnostic);
-        heap_profile::init(&runtime_config);
-        diagnostics.register(HeapProfileDiagnostic);
+        if init_options.init_globals {
+            diagnostics.register(HeapStatsDiagnostic);
+            heap_profile::init(&runtime_config);
+            diagnostics.register(HeapProfileDiagnostic);
+        }
     }
     diagnostics.register(DiagnosticTypesDiagnostic::new(Arc::downgrade(&diagnostics)));
 

--- a/witchcraft-server/src/lib.rs
+++ b/witchcraft-server/src/lib.rs
@@ -440,15 +440,15 @@ pub mod in_memory_testing {
     use conjure_error::Error;
     use refreshable::Refreshable;
     use serde::de::DeserializeOwned;
-    use std::sync::atomic::{AtomicBool, Ordering};
-    use std::sync::{mpsc, Arc};
+    use std::sync::atomic::AtomicBool;
+    use std::sync::{mpsc, Arc, Once};
     use std::thread::{self, JoinHandle};
     use tokio::runtime::Handle;
     use tokio::sync::oneshot;
     use witchcraft_server_config::install::InstallConfig;
     use witchcraft_server_config::runtime::RuntimeConfig;
 
-    static GLOBALS_INITIALIZED: std::sync::OnceLock<AtomicBool> = std::sync::OnceLock::new();
+    static INIT: Once = Once::new();
 
     /// Initializes a Witchcraft server for testing with custom config loaders. This variation of init
     /// spawns a Witchcraft server in a thread, rather than as a separate process. Note: because
@@ -475,61 +475,73 @@ pub mod in_memory_testing {
             + Send
             + 'static,
     {
-        let globals_initialized = GLOBALS_INITIALIZED.get_or_init(|| AtomicBool::new(false));
-        let init_globals = !globals_initialized.swap(true, Ordering::Relaxed);
+        let init_fn = |init_globals: bool| {
+            if init_globals {
+                logging::early_init();
+            }
 
-        if init_globals {
-            logging::early_init();
-        }
+            let (startup_result_sender, startup_result_receiver) =
+                mpsc::channel::<Result<(), Error>>();
+            let (shutdown_signal_sender, shutdown_signal_receiver) = oneshot::channel::<()>();
 
-        let (startup_result_sender, startup_result_receiver) = mpsc::channel::<Result<(), Error>>();
-        let (shutdown_signal_sender, shutdown_signal_receiver) = oneshot::channel::<()>();
+            // Dedicated thread for this server instance, allows it to create its own tokio runtime
+            let server_thread = thread::spawn(move || {
+                let mut runtime_guard = None;
 
-        // Dedicated thread for this server instance, allows it to create its own tokio runtime
-        let server_thread = thread::spawn(move || {
-            let mut runtime_guard = None;
-            let witchcraft = match init_inner(
-                init,
-                load_install,
-                load_runtime,
-                &mut runtime_guard,
-                InitOptions {
-                    init_globals,
-                    thread_prefix,
-                },
-            ) {
-                Ok(witchcraft) => witchcraft,
-                Err(e) => {
-                    let _ = startup_result_sender.send(Err(e));
-                    return;
-                }
-            };
-            // Startup OK, notify receiver waiting below
-            let _ = startup_result_sender.send(Ok(()));
+                let witchcraft = match init_inner(
+                    init,
+                    load_install,
+                    load_runtime,
+                    &mut runtime_guard,
+                    InitOptions {
+                        init_globals,
+                        thread_prefix,
+                    },
+                ) {
+                    Ok(witchcraft) => witchcraft,
+                    Err(e) => {
+                        let _ = startup_result_sender.send(Err(e));
+                        return;
+                    }
+                };
+                // Startup OK, notify receiver waiting below
+                let _ = startup_result_sender.send(Ok(()));
 
-            let handle = witchcraft.handle.clone();
-            let timeout = witchcraft.install_config.server().shutdown_timeout();
+                let handle = witchcraft.handle.clone();
+                let timeout = witchcraft.install_config.server().shutdown_timeout();
 
-            // Block the server until shutdown is called by the RunHandle's drop
-            handle.block_on(async move {
-                let _ = shutdown_signal_receiver.await;
-                drain_shutdown_hooks(witchcraft.shutdown_hooks, timeout).await;
+                // Block the server until shutdown is called by the RunHandle's drop
+                handle.block_on(async move {
+                    let _ = shutdown_signal_receiver.await;
+                    drain_shutdown_hooks(witchcraft.shutdown_hooks, timeout).await;
+                });
+                drop(runtime_guard);
             });
-            drop(runtime_guard);
+
+            // Wait for startup to finish before handing back a handle. A receive error means the thread
+            // panicked before reporting.
+            match startup_result_receiver.recv() {
+                Ok(Ok(())) => Ok(RunHandle {
+                    shutdown_signal_sender: Some(shutdown_signal_sender),
+                    server_thread: Some(server_thread),
+                }),
+                Ok(Err(e)) => Err(e), // Error during init_inner()
+                Err(_) => Err(Error::internal_safe(
+                    "in-memory server thread panicked during initialization",
+                )),
+            }
+        };
+
+        let mut init_fn = Some(init_fn);
+
+        let mut first_init_result: Option<Result<RunHandle, Error>> = None;
+        INIT.call_once(|| {
+            // Only one branch of init_fn() is guaranteed to run, this take() lets us bypass
+            // borrow checker not detecting this branching.
+            first_init_result = Some(init_fn.take().unwrap()(true));
         });
 
-        // Wait for startup to finish before handing back a handle. A receive error means the thread
-        // panicked before reporting.
-        match startup_result_receiver.recv() {
-            Ok(Ok(())) => Ok(RunHandle {
-                shutdown_signal_sender: Some(shutdown_signal_sender),
-                server_thread: Some(server_thread),
-            }),
-            Ok(Err(e)) => Err(e), // Error during init_inner()
-            Err(_) => Err(Error::internal_safe(
-                "in-memory server thread panicked during initialization",
-            )),
-        }
+        first_init_result.unwrap_or_else(|| init_fn.unwrap()(false))
     }
 
     /// Provides a handle for a running in-memory Witchcraft server. Gracefully shuts the server

--- a/witchcraft-server/src/lib.rs
+++ b/witchcraft-server/src/lib.rs
@@ -451,14 +451,15 @@ pub mod in_memory_testing {
     static GLOBALS_INITIALIZED: std::sync::OnceLock<AtomicBool> = std::sync::OnceLock::new();
 
     /// Initializes a Witchcraft server for testing with custom config loaders. This variation of init
-    /// can initialize a Witchcraft server that's running in a thread, rather than as a separate
-    /// process. Note: only one in-memory server can initialize logging (`init_log = true`). Use the
-    /// `thread_prefix` parameter to differentiate log messages across servers.
+    /// spawns a Witchcraft server in a thread, rather than as a separate process. Note: because
+    /// logging infrastructure is global to a process, the first initialized server will also
+    /// initialize logging; all subsequent ones will reuse the same log levels and appenders.
     ///
     /// The server runs on a dedicated thread, and the returned [`RunHandle`] shuts the
-    /// server down gracefully when dropped. Note that the first call to this init function will
-    /// also initialize global shared logging; and the returned handle will shut down the appenders
-    /// on drop. Ensure that first initialized server is the last one to go out of scope.
+    /// server down gracefully when dropped. Note that since the first call to this init function will
+    /// also initialize global shared logging; the corresponding returned handle will shut down the
+    /// appenders on drop, making logging unavailable to servers initialized after the first one.
+    /// Thus, ensure that first initialized server is the last one to go out of scope.
     pub fn init_with_configs_for_tests<I, R, F, LI, LR>(
         init: F,
         load_install: LI,
@@ -503,10 +504,11 @@ pub mod in_memory_testing {
                     return;
                 }
             };
+            // Startup OK, notify receiver waiting below
+            let _ = startup_result_sender.send(Ok(()));
 
             let handle = witchcraft.handle.clone();
             let timeout = witchcraft.install_config.server().shutdown_timeout();
-            let _ = startup_result_sender.send(Ok(()));
 
             // Block the server until shutdown is called by the RunHandle's drop
             handle.block_on(async move {
@@ -517,13 +519,13 @@ pub mod in_memory_testing {
         });
 
         // Wait for startup to finish before handing back a handle. A receive error means the thread
-        // panicked before reporting, dropping `startup_tx`.
+        // panicked before reporting.
         match startup_result_receiver.recv() {
             Ok(Ok(())) => Ok(RunHandle {
                 shutdown_signal_sender: Some(shutdown_signal_sender),
                 server_thread: Some(server_thread),
             }),
-            Ok(Err(e)) => Err(e), // Error during init_error()
+            Ok(Err(e)) => Err(e), // Error during init_inner()
             Err(_) => Err(Error::internal_safe(
                 "in-memory server thread panicked during initialization",
             )),

--- a/witchcraft-server/src/lib.rs
+++ b/witchcraft-server/src/lib.rs
@@ -513,7 +513,7 @@ pub mod in_memory_testing {
             // Block the server until shutdown is called by the RunHandle's drop
             handle.block_on(async move {
                 let _ = shutdown_signal_receiver.await;
-                    drain_shutdown_hooks(witchcraft.shutdown_hooks, timeout).await;
+                drain_shutdown_hooks(witchcraft.shutdown_hooks, timeout).await;
             });
             drop(runtime_guard);
         });

--- a/witchcraft-server/src/lib.rs
+++ b/witchcraft-server/src/lib.rs
@@ -440,7 +440,7 @@ pub mod in_memory_testing {
     use conjure_error::Error;
     use refreshable::Refreshable;
     use serde::de::DeserializeOwned;
-    use std::sync::atomic::AtomicBool;
+    use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::{mpsc, Arc, Once};
     use std::thread::{self, JoinHandle};
     use tokio::runtime::Handle;
@@ -449,6 +449,7 @@ pub mod in_memory_testing {
     use witchcraft_server_config::runtime::RuntimeConfig;
 
     static INIT: Once = Once::new();
+    static FIRST_INIT_SUCCESS: AtomicBool = AtomicBool::new(false);
 
     /// Initializes a Witchcraft server for testing with custom config loaders. This variation of init
     /// spawns a Witchcraft server in a thread, rather than as a separate process. Note: because
@@ -538,10 +539,17 @@ pub mod in_memory_testing {
         INIT.call_once(|| {
             // Only one branch of init_fn() is guaranteed to run, this take() lets us bypass
             // borrow checker not detecting this branching.
-            first_init_result = Some(init_fn.take().unwrap()(true));
+            let res = init_fn.take().unwrap()(true);
+            FIRST_INIT_SUCCESS.store(res.is_ok(), Ordering::Relaxed);
+            first_init_result = Some(res);
         });
 
-        first_init_result.unwrap_or_else(|| init_fn.unwrap()(false))
+        first_init_result.unwrap_or_else(|| {
+            if !FIRST_INIT_SUCCESS.load(Ordering::Relaxed) {
+                return Err(Error::internal_safe("Initial init failed, not continuing"));
+            }
+            init_fn.take().unwrap()(false)
+        })
     }
 
     /// Provides a handle for a running in-memory Witchcraft server. Gracefully shuts the server

--- a/witchcraft-server/src/logging/mod.rs
+++ b/witchcraft-server/src/logging/mod.rs
@@ -46,6 +46,7 @@ pub(crate) static AUDIT_LOGGER: AtomicLazyCell<Arc<Mutex<Appender<AuditLogV3>>>>
     AtomicLazyCell::NONE;
 
 static EVENT_LOGGER: OnceCell<Appender<EventLogV2>> = OnceCell::new();
+static REQUEST_LOGGER: OnceCell<Arc<Appender<RequestLogV2>>> = OnceCell::new();
 
 pub(crate) const REQUEST_ID_KEY: &str = "_requestId";
 pub(crate) const SAMPLED_KEY: &str = "_sampled";
@@ -74,6 +75,11 @@ pub(crate) async fn init(
     let audit_logger = Arc::new(Mutex::new(audit_logger));
     let event_logger = logger::appender(install, metrics, hooks).await?;
 
+    REQUEST_LOGGER
+        .set(request_logger.clone())
+        .ok()
+        .expect("Request logger already initialized");
+
     AUDIT_LOGGER
         .fill(audit_logger.clone())
         .ok()
@@ -89,6 +95,21 @@ pub(crate) async fn init(
     Ok(Loggers {
         request_logger,
         audit_logger,
+    })
+}
+
+pub(crate) fn get_existing() -> Result<Loggers, Error> {
+    let audit_logger = AUDIT_LOGGER
+        .borrow()
+        .ok_or_else(|| Error::internal_safe("Audit logger not initialized"))?;
+
+    let request_logger = REQUEST_LOGGER
+        .get()
+        .ok_or_else(|| Error::internal_safe("Event logger not initialized"))?;
+
+    Ok(Loggers {
+        request_logger: request_logger.clone(),
+        audit_logger: audit_logger.clone(),
     })
 }
 

--- a/witchcraft-server/src/witchcraft.rs
+++ b/witchcraft-server/src/witchcraft.rs
@@ -39,7 +39,7 @@ pub struct Witchcraft {
     pub(crate) handle: Handle,
     pub(crate) install_config: InstallConfig,
     pub(crate) thread_pool: Option<Arc<ThreadPool>>,
-    pub(crate) thread_prefix: String,
+    pub(crate) thread_prefix: Option<String>,
     pub(crate) endpoints: Vec<Box<dyn WitchcraftEndpoint + Sync + Send>>,
     pub(crate) shutdown_hooks: ShutdownHooks,
     pub(crate) conjure_runtime: Arc<ConjureRuntime>,

--- a/witchcraft-server/src/witchcraft.rs
+++ b/witchcraft-server/src/witchcraft.rs
@@ -39,6 +39,7 @@ pub struct Witchcraft {
     pub(crate) handle: Handle,
     pub(crate) install_config: InstallConfig,
     pub(crate) thread_pool: Option<Arc<ThreadPool>>,
+    pub(crate) thread_prefix: String,
     pub(crate) endpoints: Vec<Box<dyn WitchcraftEndpoint + Sync + Send>>,
     pub(crate) shutdown_hooks: ShutdownHooks,
     pub(crate) conjure_runtime: Arc<ConjureRuntime>,
@@ -140,9 +141,13 @@ impl Witchcraft {
             Box<dyn Endpoint<blocking::RequestBody, blocking::ResponseWriter> + Sync + Send>,
         >,
     ) {
-        let thread_pool = self
-            .thread_pool
-            .get_or_insert_with(|| Arc::new(ThreadPool::new(&self.install_config, &self.metrics)));
+        let thread_pool = self.thread_pool.get_or_insert_with(|| {
+            Arc::new(ThreadPool::new(
+                &self.install_config,
+                &self.metrics,
+                self.thread_prefix.clone(),
+            ))
+        });
 
         self.endpoints.extend(
             endpoints


### PR DESCRIPTION
## Before this PR
Witchcraft server initialization assumes that a single WC is running in a dedicated process. As part of initialization, it sets a number of global singletons which can only be set once. 

Applications may want to initialize Witchcraft in their testing infrastructure by spawning a thread to run separate instances of Witchcraft. However, this is currently not possible because initialization of global logging singletons fails after the first init.

## After this PR
Added a variation of init method which allows bypassing logging initialization and reusing previously initialized loggers (either externally initialized, or initializing them during first server instance init).

