### PR TITLE
Do not do global logging init in test servers

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,0 +1,158 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AutoImportSettings">
+    <option name="autoReloadType" value="ALL" />
+  </component>
+  <component name="CargoProjects">
+    <cargoProject FILE="$PROJECT_DIR$/Cargo.toml">
+      <package file="$PROJECT_DIR$/render-conjure">
+        <feature name="default" enabled="true" />
+      </package>
+      <package file="$PROJECT_DIR$/witchcraft-server">
+        <feature name="default" enabled="true" />
+        <feature name="in-memory-testing" enabled="true" />
+      </package>
+      <package file="$PROJECT_DIR$/witchcraft-server-config">
+        <feature name="default" enabled="true" />
+      </package>
+      <package file="$PROJECT_DIR$/witchcraft-server-ete">
+        <feature name="default" enabled="true" />
+      </package>
+      <package file="$PROJECT_DIR$/witchcraft-server-macros">
+        <feature name="default" enabled="true" />
+      </package>
+    </cargoProject>
+  </component>
+  <component name="ChangeListManager">
+    <list default="true" id="9cfbed6b-cf7c-44a0-bd7b-aff73deca127" name="Changes" comment="">
+      <change beforePath="$PROJECT_DIR$/witchcraft-server/src/lib.rs" beforeDir="false" afterPath="$PROJECT_DIR$/witchcraft-server/src/lib.rs" afterDir="false" />
+    </list>
+    <option name="SHOW_DIALOG" value="false" />
+    <option name="HIGHLIGHT_CONFLICTS" value="true" />
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+    <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+  <component name="ExecutionTargetManager" SELECTED_TARGET="RsBuildProfile:test" />
+  <component name="Git.Settings">
+    <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
+  </component>
+  <component name="GitHubPullRequestSearchHistory">{
+  &quot;lastFilter&quot;: {
+    &quot;state&quot;: &quot;OPEN&quot;,
+    &quot;assignee&quot;: &quot;arseny-bogomolov&quot;
+  }
+}</component>
+  <component name="GithubPullRequestsUISettings">{
+  &quot;selectedUrlAndAccountId&quot;: {
+    &quot;url&quot;: &quot;https://github.com/palantir/witchcraft-rust-server.git&quot;,
+    &quot;accountId&quot;: &quot;607041d4-cc02-4f26-afc0-8f20d26b490a&quot;
+  }
+}</component>
+  <component name="MacroExpansionManager">
+    <option name="directoryName" value="PmKv7bZq" />
+  </component>
+  <component name="ProjectColorInfo">{
+  &quot;customColor&quot;: &quot;&quot;,
+  &quot;associatedIndex&quot;: 3
+}</component>
+  <component name="ProjectId" id="36lTCGrOlusbjRezdOFZHB5lKNE" />
+  <component name="ProjectViewState">
+    <option name="hideEmptyMiddlePackages" value="true" />
+    <option name="showLibraryContents" value="true" />
+  </component>
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "ModuleVcsDetector.initialDetectionPerformed": "true",
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "RunOnceActivity.git.unshallow": "true",
+    "codeWithMe.voiceChat.enabledByDefault": "false",
+    "git-widget-placeholder": "ab/skip-early-logging-init",
+    "last_opened_file_path": "/Volumes/git/code/open-source/witchcraft-rust-server",
+    "node.js.detected.package.eslint": "true",
+    "node.js.detected.package.tslint": "true",
+    "node.js.selected.package.eslint": "(autodetect)",
+    "node.js.selected.package.tslint": "(autodetect)",
+    "nodejs_package_manager_path": "npm",
+    "org.rust.cargo.project.model.PROJECT_DISCOVERY": "true",
+    "org.rust.cargo.project.model.impl.CargoExternalSystemProjectAware.subscribe.first.balloon": "",
+    "org.rust.first.attach.projects": "true",
+    "settings.editor.selected.configurable": "language.rust.cargo.check",
+    "vue.rearranger.settings.migration": "true"
+  }
+}]]></component>
+  <component name="RsExternalLinterProjectSettings">
+    <option name="tool" value="Clippy" />
+  </component>
+  <component name="RunManager" selected="Cargo.Test witchcraft-rust-server">
+    <configuration name="Run render-conjure" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
+      <option name="command" value="run --package render-conjure --bin render-conjure" />
+      <option name="workingDirectory" value="file://$PROJECT_DIR$" />
+      <envs />
+      <option name="emulateTerminal" value="true" />
+      <option name="channel" value="DEFAULT" />
+      <option name="requiredFeatures" value="true" />
+      <option name="allFeatures" value="false" />
+      <option name="withSudo" value="false" />
+      <option name="buildTarget" value="REMOTE" />
+      <option name="backtrace" value="SHORT" />
+      <option name="isRedirectInput" value="false" />
+      <option name="redirectInputPath" value="" />
+      <method v="2">
+        <option name="CARGO.BUILD_TASK_PROVIDER" enabled="true" />
+      </method>
+    </configuration>
+    <configuration name="Run witchcraft-server-ete" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
+      <option name="command" value="run --package witchcraft-server-ete --bin witchcraft-server-ete" />
+      <option name="workingDirectory" value="file://$PROJECT_DIR$" />
+      <envs />
+      <option name="emulateTerminal" value="true" />
+      <option name="channel" value="DEFAULT" />
+      <option name="requiredFeatures" value="true" />
+      <option name="allFeatures" value="false" />
+      <option name="withSudo" value="false" />
+      <option name="buildTarget" value="REMOTE" />
+      <option name="backtrace" value="SHORT" />
+      <option name="isRedirectInput" value="false" />
+      <option name="redirectInputPath" value="" />
+      <method v="2">
+        <option name="CARGO.BUILD_TASK_PROVIDER" enabled="true" />
+      </method>
+    </configuration>
+    <configuration name="Test witchcraft-rust-server" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
+      <option name="buildProfileId" value="test" />
+      <option name="command" value="test --workspace" />
+      <option name="workingDirectory" value="file://$PROJECT_DIR$" />
+      <envs />
+      <option name="emulateTerminal" value="true" />
+      <option name="channel" value="DEFAULT" />
+      <option name="requiredFeatures" value="true" />
+      <option name="allFeatures" value="false" />
+      <option name="withSudo" value="false" />
+      <option name="buildTarget" value="REMOTE" />
+      <option name="backtrace" value="SHORT" />
+      <option name="isRedirectInput" value="false" />
+      <option name="redirectInputPath" value="" />
+      <method v="2">
+        <option name="CARGO.BUILD_TASK_PROVIDER" enabled="true" />
+      </method>
+    </configuration>
+  </component>
+  <component name="RustProjectSettings">
+    <option name="toolchainHomeDirectory" value="$USER_HOME$/.cargo/bin" />
+  </component>
+  <component name="TaskManager">
+    <task active="true" id="Default" summary="Default task">
+      <changelist id="9cfbed6b-cf7c-44a0-bd7b-aff73deca127" name="Changes" comment="" />
+      <created>1765580029442</created>
+      <option name="number" value="Default" />
+      <option name="presentableId" value="Default" />
+      <updated>1765580029442</updated>
+      <workItem from="1765580030718" duration="1034000" />
+      <workItem from="1765646112479" duration="606000" />
+    </task>
+    <servers />
+  </component>
+  <component name="TypeScriptGeneratedFilesManager">
+    <option name="version" value="3" />
+  </component>
+</project>

--- a/witchcraft-server/src/lib.rs
+++ b/witchcraft-server/src/lib.rs
@@ -436,7 +436,7 @@ where
 /// Variation of the Witchcraft server initialization, which can be used for testing. Allows
 /// spawning multiple instances of the server in memory.
 pub mod in_memory_testing {
-    use crate::{drain_shutdown_hooks, init_inner, logging, InitOptions, Witchcraft};
+    use crate::{drain_shutdown_hooks, init_inner, InitOptions, Witchcraft};
     use conjure_error::Error;
     use refreshable::Refreshable;
     use serde::de::DeserializeOwned;
@@ -454,11 +454,13 @@ pub mod in_memory_testing {
     /// Initializes a Witchcraft server for testing with custom config loaders. This variation of init
     /// spawns a Witchcraft server in a thread, rather than as a separate process. Note: because
     /// logging infrastructure is global to a process, the first initialized server will also
-    /// initialize logging; all subsequent ones will reuse the same log levels and appenders.
+    /// initialize logging appenders; all subsequent ones will reuse the same appenders. However,
+    /// the actual service logger implementation and log level must be set globally once by the
+    /// calling test code.
     ///
     /// The server runs on a dedicated thread, and the returned [`RunHandle`] shuts the
     /// server down gracefully when dropped. Note that since the first call to this init function will
-    /// also initialize global shared logging; the corresponding returned handle will shut down the
+    /// also initialize the global logging appenders; the corresponding returned handle will shut down the
     /// appenders on drop, making logging unavailable to servers initialized after the first one.
     /// Thus, ensure that first initialized server is the last one to go out of scope.
     pub fn init_with_configs_for_tests<I, R, F, LI, LR>(
@@ -477,10 +479,6 @@ pub mod in_memory_testing {
             + 'static,
     {
         let init_fn = |init_globals: bool| {
-            if init_globals {
-                logging::early_init();
-            }
-
             let (startup_result_sender, startup_result_receiver) =
                 mpsc::channel::<Result<(), Error>>();
             let (shutdown_signal_sender, shutdown_signal_receiver) = oneshot::channel::<()>();


### PR DESCRIPTION
## Before this PR
Original change in #291 did not account for calling test code initializing the global logger implementation. 

## After this PR
It is now on the calling code to initialize the logger implementation and default logging level.
