### PR TITLE
Disable the deprecated x-xss-protection header

### DIFF
--- a/witchcraft-server/src/service/web_security.rs
+++ b/witchcraft-server/src/service/web_security.rs
@@ -30,7 +30,7 @@ const X_CONTENT_TYPE_OPTIONS_VALUE: HeaderValue = HeaderValue::from_static("nosn
 #[allow(clippy::declare_interior_mutable_const)]
 const X_FRAME_OPTIONS_VALUE: HeaderValue = HeaderValue::from_static("sameorigin");
 #[allow(clippy::declare_interior_mutable_const)]
-const X_XSS_PROTECTION_VALUE: HeaderValue = HeaderValue::from_static("1; mode=block");
+const X_XSS_PROTECTION_VALUE: HeaderValue = HeaderValue::from_static("0");
 
 #[allow(clippy::declare_interior_mutable_const)]
 const X_CONTENT_SECURITY_POLICY: HeaderName = HeaderName::from_static("x-content-security-policy");


### PR DESCRIPTION
This header is deprecated and prone to vulnerabilities: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-XSS-Protection.

Explicitly disabling it to mirror the equivalent change in WC-Java.