### PR TITLE
Allow overriding content security policies per endpoint

### DIFF
--- a/witchcraft-server/src/service/web_security.rs
+++ b/witchcraft-server/src/service/web_security.rs
@@ -13,8 +13,8 @@
 // limitations under the License.
 use crate::service::{Layer, Service};
 use http::header::{
-    Entry, HeaderName, CONTENT_SECURITY_POLICY, REFERRER_POLICY, USER_AGENT, X_CONTENT_TYPE_OPTIONS,
-    X_FRAME_OPTIONS, X_XSS_PROTECTION,
+    Entry, HeaderName, CONTENT_SECURITY_POLICY, REFERRER_POLICY, USER_AGENT,
+    X_CONTENT_TYPE_OPTIONS, X_FRAME_OPTIONS, X_XSS_PROTECTION,
 };
 use http::{HeaderValue, Request, Response};
 

--- a/witchcraft-server/src/service/web_security.rs
+++ b/witchcraft-server/src/service/web_security.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 use crate::service::{Layer, Service};
 use http::header::{
-    HeaderName, CONTENT_SECURITY_POLICY, REFERRER_POLICY, USER_AGENT, X_CONTENT_TYPE_OPTIONS,
+    Entry, HeaderName, CONTENT_SECURITY_POLICY, REFERRER_POLICY, USER_AGENT, X_CONTENT_TYPE_OPTIONS,
     X_FRAME_OPTIONS, X_XSS_PROTECTION,
 };
 use http::{HeaderValue, Request, Response};
@@ -68,9 +68,9 @@ where
             .is_some_and(|s| s.contains(USER_AGENT_IE_10) || s.contains(USER_AGENT_IE_11));
 
         let mut response = self.inner.call(req).await;
-        response
-            .headers_mut()
-            .insert(CONTENT_SECURITY_POLICY, CONTENT_SECURITY_POLICY_VALUE);
+        if let Entry::Vacant(e) = response.headers_mut().entry(CONTENT_SECURITY_POLICY) {
+            e.insert(CONTENT_SECURITY_POLICY_VALUE);
+        }
         response
             .headers_mut()
             .insert(REFERRER_POLICY, REFERRER_POLICY_VALUE);


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Previously the web_security layer overrode all CSP headers set by the endpoint handler. The Java version of witchcraft defers to conjure java [here](https://github.com/palantir/conjure-java/blob/e74a3e0cb9a1ec9a2c5a45aa55422f943beb1af4/conjure-java-undertow-runtime/src/main/java/com/palantir/conjure/java/undertow/runtime/WebSecurityHandler.java), which runs the web security layer before running the request, which allows endpoints to override the default CSPs set by conjure. 

This is necessary to better support serving FE assets

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Allow overriding content security policies per endpoint
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

